### PR TITLE
[WIP]Ekf2: centralize estimator alignement

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -486,21 +486,18 @@ void Ekf::controlOpticalFlowFusion()
 			&& isTerrainEstimateValid())
 		{
 
-			// If the heading is valid and use is not inhibited , start using optical flow aiding
-			if (_control_status.flags.yaw_align) {
-				// set the flag and reset the fusion timeout
-				_control_status.flags.opt_flow = true;
-				_time_last_of_fuse = _time_last_imu;
+			// set the flag and reset the fusion timeout
+			_control_status.flags.opt_flow = true;
+			_time_last_of_fuse = _time_last_imu;
 
-				// if we are not using GPS or external vision aiding, then the velocity and position states and covariances need to be set
-				const bool flow_aid_only = !(_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel);
-				if (flow_aid_only) {
-					resetVelocity();
-					resetPosition();
+			// if we are not using GPS or external vision aiding, then the velocity and position states and covariances need to be set
+			const bool flow_aid_only = !(_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel);
+			if (flow_aid_only) {
+				resetVelocity();
+				resetPosition();
 
-					// align the output observer to the EKF states
-					alignOutputFilter();
-				}
+				// align the output observer to the EKF states
+				alignOutputFilter();
 			}
 
 		} else if (!(_params.fusion_mode & MASK_USE_OF)) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -57,7 +57,6 @@ void Ekf::controlFusionModes()
 		// and declare the tilt alignment complete
 		if ((angle_err_var_vec(0) + angle_err_var_vec(1)) < sq(math::radians(3.0f))) {
 			_control_status.flags.tilt_align = true;
-			_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState()); // TODO: is this needed?
 
 			// send alignment status message to the console
 			const char* height_source = nullptr;
@@ -486,10 +485,6 @@ void Ekf::controlOpticalFlowFusion()
 			&& !_inhibit_flow_use
 			&& isTerrainEstimateValid())
 		{
-			// If the heading is not aligned, reset the yaw and magnetic field states
-			if (!_control_status.flags.yaw_align) {
-				_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState());
-			}
 
 			// If the heading is valid and use is not inhibited , start using optical flow aiding
 			if (_control_status.flags.yaw_align) {
@@ -598,25 +593,12 @@ void Ekf::controlGpsFusion()
 		bool gps_checks_failing = (_time_last_imu - _last_gps_pass_us > (uint64_t)5e6);
 		if ((_params.fusion_mode & MASK_USE_GPS) && !_control_status.flags.gps) {
 			if (_control_status.flags.tilt_align && _NED_origin_initialised && gps_checks_passing) {
-				// If the heading is not aligned, reset the yaw and magnetic field states
-				// Do not use external vision for yaw if using GPS because yaw needs to be
-				// defined relative to an NED reference frame
-				const bool want_to_reset_mag_heading = !_control_status.flags.yaw_align ||
-								       _control_status.flags.ev_yaw ||
-								       _mag_inhibit_yaw_reset_req;
-				if (want_to_reset_mag_heading && canResetMagHeading()) {
-					_control_status.flags.ev_yaw = false;
-					_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState());
-					// Handle the special case where we have not been constraining yaw drift or learning yaw bias due
-					// to assumed invalid mag field associated with indoor operation with a downwards looking flow sensor.
-					if (_mag_inhibit_yaw_reset_req) {
-						_mag_inhibit_yaw_reset_req = false;
-						// Zero the yaw bias covariance and set the variance to the initial alignment uncertainty
-						P.uncorrelateCovarianceSetVariance<1>(12, sq(_params.switch_on_gyro_bias * FILTER_UPDATE_PERIOD_S));
-					}
-				}
+				// If the heading is aligned for yaw vision, reset the yaw and magnetic field states
+				_mag_yaw_reset_req = _mag_yaw_reset_req
+						     || _control_status.flags.ev_yaw;
 
-				const bool is_heading_valid = _control_status.flags.yaw_align && !_mag_yaw_reset_req;
+				// Do not start GPS fusion if a yaw reset is currently requested
+				const bool is_heading_valid = !isYawResetRequested();
 
 				if (is_heading_valid) {
 					// do not reset the velocity estimate if optical flow aiding is active
@@ -667,14 +649,14 @@ void Ekf::controlGpsFusion()
 
 			if (do_reset) {
 				// use GPS velocity data to check and correct yaw angle if a FW vehicle
-				if (_control_status.flags.fixed_wing && _control_status.flags.in_air) {
+				if (canRealignYawUsingGps()) {
 					// if flying a fixed wing aircraft, do a complete reset that includes yaw
 					_control_status.flags.mag_aligned_in_flight = realignYawGPS();
 				}
+				//TODO: should we also reset heading for a multicopter?
 
-				resetVelocity();
-				resetPosition();
-				_velpos_reset_request = false;
+				_velpos_reset_request = true;
+				runVelPosReset(); // TODO: set the request flag here, but move the actual reset somewhere else
 				ECL_WARN_TIMESTAMPED("GPS fusion timeout - reset to GPS");
 
 				// Reset the timeout counters
@@ -686,8 +668,6 @@ void Ekf::controlGpsFusion()
 
 		// Only use GPS data for position and velocity aiding if enabled
 		if (_control_status.flags.gps) {
-
-
 			Vector2f gps_vel_innov_gates; // [horizontal vertical]
 			Vector2f gps_pos_innov_gates; // [horizontal vertical]
 			Vector3f gps_vel_obs_var;

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -194,7 +194,7 @@ bool Ekf::initialiseFilter()
 
 		// calculate the initial magnetic field and yaw alignment
 		checkMagFieldStrength();
-		processMagResetFlags();
+		processMagResetFlags(true);
 
 		// try to initialise the terrain estimator
 		_terrain_initialised = initHagl();

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -193,7 +193,8 @@ bool Ekf::initialiseFilter()
 		}
 
 		// calculate the initial magnetic field and yaw alignment
-		_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState(), true, false);
+		checkMagFieldStrength();
+		processMagResetFlags();
 
 		// try to initialise the terrain estimator
 		_terrain_initialised = initHagl();

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -193,14 +193,7 @@ bool Ekf::initialiseFilter()
 		}
 
 		// calculate the initial magnetic field and yaw alignment
-		_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState(), false, false);
-
-
-		// update the yaw angle variance using the variance of the measurement
-		if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
-			// using magnetic heading tuning parameter
-			increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
-		}
+		_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState(), true, false);
 
 		// try to initialise the terrain estimator
 		_terrain_initialised = initHagl();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -688,7 +688,7 @@ private:
 	bool isMeasuredMatchingGpsMagStrength(float mag_strength) const;
 	bool isMeasuredMatchingAverageMagStrength(float mag_strength) const;
 	static bool isMeasuredMatchingExpected(float measured, float expected, float gate);
-	void processMagResetFlags();
+	void processMagResetFlags(bool force = false);
 	bool isYawResetRequested() const;
 	void runPostAlignmentActions();
 	void runMagAndMagDeclFusions();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -560,9 +560,6 @@ private:
 	// fuse single velocity and position measurement
 	void fuseVelPosHeight(const float innov, const float innov_var, const int obs_index);
 
-	// reset velocity states of the ekf
-	bool resetVelocity();
-
 	// fuse optical flow line of sight rate measurements
 	void fuseOptFlow();
 
@@ -606,8 +603,11 @@ private:
 	// Return the magnetic declination in radians to be used by the alignment and fusion processing
 	float getMagDeclination();
 
+	// reset velocity states of the ekf
+	void resetVelocity();
+
 	// reset position states of the ekf (only horizontal position)
-	bool resetPosition();
+	void resetPosition();
 
 	// reset height state of the ekf
 	void resetHeight();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -683,9 +683,10 @@ private:
 	void checkMagInhibition();
 	bool shouldInhibitMag() const;
 	void checkMagFieldStrength();
+	bool isMagStrengthPlausible(float mag_strength) const;
 	bool isStrongMagneticDisturbance() const;
-	bool isMeasuredMatchingGpsMagStrength() const;
-	bool isMeasuredMatchingAverageMagStrength() const;
+	bool isMeasuredMatchingGpsMagStrength(float mag_strength) const;
+	bool isMeasuredMatchingAverageMagStrength(float mag_strength) const;
 	static bool isMeasuredMatchingExpected(float measured, float expected, float gate);
 	void processMagResetFlags();
 	bool isYawResetRequested() const;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -371,7 +371,7 @@ private:
 	uint8_t _num_bad_flight_yaw_events{0};	///< number of times a bad heading has been detected in flight and required a yaw reset
 	uint64_t _mag_use_not_inhibit_us{0};	///< last system time in usec before magnetometer use was inhibited
 	bool _mag_use_inhibit{false};		///< true when magnetometer use is being inhibited
-	bool _mag_use_inhibit_prev{false};	///< true when magnetometer use was being inhibited the previous frame
+	bool _in_flight_yaw_reset_req{false};	///< true when an in-flight alignement is requested
 	bool _mag_inhibit_yaw_reset_req{false};	///< true when magnetometer inhibit has been active for long enough to require a yaw reset when conditions improve.
 	float _last_static_yaw{0.0f};		///< last yaw angle recorded when on ground motion checks were passing (rad)
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
@@ -687,6 +687,9 @@ private:
 	bool isMeasuredMatchingGpsMagStrength() const;
 	bool isMeasuredMatchingAverageMagStrength() const;
 	static bool isMeasuredMatchingExpected(float measured, float expected, float gate);
+	void processMagResetFlags();
+	bool isYawResetRequested() const;
+	void runPostAlignmentActions();
 	void runMagAndMagDeclFusions();
 	void run3DMagAndDeclFusions();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -47,7 +47,7 @@
 
 // Reset the velocity states. If we have a recent and valid
 // gps measurement then use for velocity initialisation
-bool Ekf::resetVelocity()
+void Ekf::resetVelocity()
 {
 	// used to calculate the velocity change due to the reset
 	Vector3f vel_before_reset = _state.vel;
@@ -126,13 +126,11 @@ bool Ekf::resetVelocity()
 	_state_reset_status.velD_change = velocity_change(2);
 	_state_reset_status.velNE_counter++;
 	_state_reset_status.velD_counter++;
-
-	return true;
 }
 
 // Reset position states. If we have a recent and valid
 // gps measurement then use for position initialisation
-bool Ekf::resetPosition()
+void Ekf::resetPosition()
 {
 	// ECL_INFO_TIMESTAMPED("Reset Position");
 	// used to calculate the position change due to the reset
@@ -209,8 +207,6 @@ bool Ekf::resetPosition()
 	// capture the reset event
 	_state_reset_status.posNE_change = posNE_change;
 	_state_reset_status.posNE_counter++;
-
-	return true;
 }
 
 // Reset height state using the last height measurement

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -436,7 +436,6 @@ bool Ekf::realignYawGPS()
 				// This is our first flight alignment so we can assume that the recent change in velocity has occurred due to a
 				// forward direction takeoff or launch and therefore the inertial and GPS ground course discrepancy is due to yaw error
 				euler321(2) += courseYawError;
-				_control_status.flags.mag_aligned_in_flight = true;
 
 			} else if (_control_status.flags.wind) {
 				// we have previously aligned yaw in-flight and have wind estimates so set the yaw such that the vehicle nose is
@@ -526,9 +525,8 @@ bool Ekf::realignYawGPS()
 		}
 
 	} else {
-		// attempt a normal alignment using the magnetometer
-		return resetMagHeading(_mag_lpf.getState());
-
+		// Yaw aligment using GPS failed
+		return false;
 	}
 }
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -541,7 +541,6 @@ bool Ekf::resetMagHeading(const Vector3f &mag_init, bool increase_yaw_var, bool 
 	}
 
 	if (_params.mag_fusion_type >= MAG_FUSE_TYPE_NONE) {
-		stopMagFusion();
 		return false;
 	}
 

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -297,9 +297,9 @@ bool Ekf::isMeasuredMatchingExpected(const float measured, const float expected,
 		&& (measured <= expected + gate);
 }
 
-void Ekf::processMagResetFlags()
+void Ekf::processMagResetFlags(bool force)
 {
-	if (isYawResetRequested() && isYawResetAuthorized()) {
+	if ((isYawResetRequested() && isYawResetAuthorized()) || force) {
 		bool has_realigned_yaw = false;
 
 		if (canRealignYawUsingGps()) {
@@ -307,7 +307,7 @@ void Ekf::processMagResetFlags()
 			runVelPosReset(); // TODO: move this somewhere else
 		}
 
-		if (!has_realigned_yaw && canResetMagHeading()) {
+		if ((!has_realigned_yaw && canResetMagHeading()) || force) {
 			has_realigned_yaw = _control_status.flags.yaw_align
 					    ? resetMagHeading(_mag_lpf.getState()) // standard reset
 					    : resetMagHeading(_mag_lpf.getState(), true, false); // initial alignement

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -43,6 +43,7 @@ void Ekf::controlMagFusion()
 {
 	updateMagFilter();
 	checkMagFieldStrength();
+	processMagResetFlags();
 
 	// If we are on ground, store the local position and time to use as a reference
 	// Also reset the flight alignment flag so that the mag fields will be re-initialised next time we achieve flight altitude
@@ -60,14 +61,7 @@ void Ekf::controlMagFusion()
 	}
 
 	if (canRunMagFusion()) {
-		if (_control_status.flags.in_air) {
-			checkHaglYawResetReq();
-			runInAirYawReset();
-			runVelPosReset();
-
-		} else {
-			runOnGroundYawReset();
-		}
+		checkHaglYawResetReq();
 
 		// Determine if we should use simple magnetic heading fusion which works better when
 		// there are large external disturbances or the more accurate 3-axis fusion
@@ -121,24 +115,13 @@ void Ekf::checkHaglYawResetReq()
 		// and request a yaw reset if not already requested.
 		static constexpr float mag_anomalies_max_hagl = 1.5f;
 		const bool above_mag_anomalies = (getTerrainVPos() - _state.pos(2)) > mag_anomalies_max_hagl;
-		_mag_yaw_reset_req = _mag_yaw_reset_req || above_mag_anomalies;
+		_in_flight_yaw_reset_req = above_mag_anomalies;
 	}
 }
 
 float Ekf::getTerrainVPos() const
 {
 	return isTerrainEstimateValid() ? _terrain_vpos : _last_on_ground_posD;
-}
-
-void Ekf::runOnGroundYawReset()
-{
-	if (_mag_yaw_reset_req && isYawResetAuthorized()) {
-		const bool has_realigned_yaw = canResetMagHeading()
-					       ? resetMagHeading(_mag_lpf.getState())
-					       : false;
-
-		_mag_yaw_reset_req = !has_realigned_yaw;
-	}
 }
 
 bool Ekf::isYawResetAuthorized() const
@@ -151,22 +134,9 @@ bool Ekf::canResetMagHeading() const
 	return !isStrongMagneticDisturbance();
 }
 
-void Ekf::runInAirYawReset()
-{
-	if (_mag_yaw_reset_req && isYawResetAuthorized()) {
-		bool has_realigned_yaw = false;
-
-		if (canRealignYawUsingGps()) { has_realigned_yaw = realignYawGPS(); }
-		else if (canResetMagHeading()) { has_realigned_yaw = resetMagHeading(_mag_lpf.getState()); }
-
-		_mag_yaw_reset_req = !has_realigned_yaw;
-		_control_status.flags.mag_aligned_in_flight = has_realigned_yaw;
-	}
-}
-
 bool Ekf::canRealignYawUsingGps() const
-{
-	return _control_status.flags.fixed_wing;
+{ 
+	return _control_status.flags.fixed_wing && _control_status.flags.in_air;
 }
 
 void Ekf::runVelPosReset()
@@ -318,6 +288,55 @@ bool Ekf::isMeasuredMatchingExpected(const float measured, const float expected,
 {
 	return (measured >= expected - gate)
 		&& (measured <= expected + gate);
+}
+
+void Ekf::processMagResetFlags()
+{
+	if (isYawResetRequested() && isYawResetAuthorized()) {
+		bool has_realigned_yaw = false;
+
+		if (canRealignYawUsingGps()) {
+			has_realigned_yaw = realignYawGPS();
+			runVelPosReset(); // TODO: move this somewhere else
+		}
+
+		if (!has_realigned_yaw && canResetMagHeading()) {
+			has_realigned_yaw = _control_status.flags.yaw_align
+					    ? resetMagHeading(_mag_lpf.getState()) // standard reset
+					    : resetMagHeading(_mag_lpf.getState(), true, false); // initial alignement
+		}
+
+		if (has_realigned_yaw) {
+			runPostAlignmentActions();
+		}
+	}
+}
+
+bool Ekf::isYawResetRequested() const
+{
+	return _mag_yaw_reset_req ||
+	       _mag_inhibit_yaw_reset_req ||
+	       _in_flight_yaw_reset_req ||
+	       !_control_status.flags.yaw_align;
+}
+
+void Ekf::runPostAlignmentActions()
+{
+	_control_status.flags.yaw_align = true;
+	_mag_yaw_reset_req = false;
+
+	if (_in_flight_yaw_reset_req) {
+		_control_status.flags.mag_aligned_in_flight = true;
+		_in_flight_yaw_reset_req = false;
+	}
+
+	// Handle the special case where we have not been constraining yaw drift or learning yaw bias due
+	// to assumed invalid mag field associated with indoor operation with a downwards looking flow sensor.
+	if (_mag_inhibit_yaw_reset_req) {
+		// Zero the yaw bias covariance and set the variance to the initial alignment uncertainty
+		P.uncorrelateCovarianceSetVariance<1>(12, sq(_params.switch_on_gyro_bias * FILTER_UPDATE_PERIOD_S));
+		_mag_inhibit_yaw_reset_req = false;
+	}
 }
 
 void Ekf::runMagAndMagDeclFusions()

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -54,8 +54,9 @@ void Ekf::controlMagFusion()
 	}
 
 	if ((_params.mag_fusion_type >= MAG_FUSE_TYPE_NONE)
-	    || _control_status.flags.mag_fault
-	    || !_control_status.flags.yaw_align) {
+	    || _control_status.flags.mag_fault) {
+		// NOTE: we still run the mag fusion logic if the flag _mag_use_inhibit is set because
+		// we need to fuse fake data to constrain the drift (done in fuseHeading)
 		stopMagFusion();
 		return;
 	}
@@ -126,7 +127,7 @@ float Ekf::getTerrainVPos() const
 
 bool Ekf::isYawResetAuthorized() const
 {
-	return !_mag_use_inhibit;
+	return !_mag_use_inhibit && _control_status.flags.tilt_align;
 }
 
 bool Ekf::canResetMagHeading() const

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -735,7 +735,6 @@ void Ekf::fuseHeading()
 		_last_static_yaw = predicted_hdg;
 
 	}
-	_mag_use_inhibit_prev = _mag_use_inhibit;
 
 	// wrap the innovation to the interval between +-pi
 	_heading_innov = wrap_pi(_heading_innov);


### PR DESCRIPTION
Move all the `resetMagHeading` calls in a central place that checks the mag field, proceed to the reset and clear/set the desired flags. This avoids copy/paste mistakes and offers a consistent and deterministic behavior.

The  initial alignment of the EKF is robustified as it also used this logic and prevents aligning when the mag field is disturbed.
During the test below, I exposed the vehicle to a strong magnetic disturbance until t=75s, the yaw then aligns.
![2019-12-23_18-39-58_01_plot](https://user-images.githubusercontent.com/14822839/71372685-51ce3c00-25b5-11ea-91c6-682faca80d50.png)


Others:
- remove unused `_mag_use_inhibit_prev`

TODO:
- [ ] non-regression SITL tests
- [ ] unit test coverage