### PR TITLE
EKF: Use IMU clipping to adjudicate bad accel data check

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -354,7 +354,7 @@ struct parameters {
 	float bcoef_y{25.0f};			///< ballistic coefficient along the Y-axis (kg/m**2)
 
 	// control of accel error detection and mitigation (IMU clipping)
-	float vert_innov_test_lim{4.5f};	///< Number of standard deviations allowed before the combined vertical velocity and position test is declared as failed
+	float vert_innov_test_lim{3.0f};	///< Number of standard deviations allowed before the combined vertical velocity and position test is declared as failed
 	int bad_acc_reset_delay_us{500000};	///< Continuous time that the vertical position and velocity innovation test must fail before the states are reset (uSec)
 
 	// auxiliary velocity fusion

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -898,8 +898,8 @@ void Ekf::checkVerticalAccelerationHealth()
 	// Don't use stale innovation data.
 	bool is_inertial_nav_falling = false;
 	bool are_vertical_pos_and_vel_independant = false;
-	if (_time_last_imu < _vert_pos_fuse_time_us + 1000000) {
-		if (_time_last_imu < _vert_vel_fuse_time_us + 1000000) {
+	if (isRecent(_vert_pos_fuse_time_us, 1000000)) {
+		if (isRecent(_vert_vel_fuse_time_us, 1000000)) {
 			// If vertical position and velocity come from independent sensors then we can
 			// trust them more if they disagree with the IMU, but need to check that they agree
 			const bool using_gps_for_both = _control_status.flags.gps_hgt && _control_status.flags.gps;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -893,8 +893,8 @@ void Ekf::checkVerticalAccelerationHealth()
 {
 	// Check for IMU accelerometer vibration induced clipping as evidenced by the vertical
 	// innovations being positive and not stale.
-	// Clipping causes the average accel reading to move towards zero which makes the INS
-	// think it is falling and produces positive vertical innovations
+	// Clipping usually causes the average accel reading to move towards zero which makes the INS
+	// think it is falling and produces positive vertical innovations.
 	// Don't use stale innovation data.
 	bool is_inertial_nav_falling = false;
 	bool are_vertical_pos_and_vel_independant = false;
@@ -905,13 +905,8 @@ void Ekf::checkVerticalAccelerationHealth()
 			const bool using_gps_for_both = _control_status.flags.gps_hgt && _control_status.flags.gps;
 			const bool using_ev_for_both = _control_status.flags.ev_hgt && _control_status.flags.ev_vel;
 			are_vertical_pos_and_vel_independant = !(using_gps_for_both || using_ev_for_both);
-			if (are_vertical_pos_and_vel_independant) {
-				if (_vert_pos_innov_ratio > 0.0f && _vert_vel_innov_ratio > 0.0f) {
-					is_inertial_nav_falling = _vert_pos_innov_ratio * _vert_vel_innov_ratio > 0.5f * sq(_params.vert_innov_test_lim);
-				}
-			} else {
-				is_inertial_nav_falling = _vert_vel_innov_ratio > _params.vert_innov_test_lim || _vert_pos_innov_ratio > _params.vert_innov_test_lim;
-			}
+			is_inertial_nav_falling |= _vert_vel_innov_ratio > _params.vert_innov_test_lim && _vert_pos_innov_ratio > 0.0f;
+			is_inertial_nav_falling |= _vert_pos_innov_ratio > _params.vert_innov_test_lim && _vert_vel_innov_ratio > 0.0f;
 		} else {
 			// only height sensing available
 			is_inertial_nav_falling = _vert_pos_innov_ratio > _params.vert_innov_test_lim;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -898,7 +898,7 @@ void Ekf::checkVerticalAccelerationHealth()
 	// Don't use stale innovation data.
 	bool is_inertial_nav_falling = false;
 	bool are_vertical_pos_and_vel_independant = false;
-	if (isRecent(_vert_pos_fuse_time_us, 1000000)) {
+	if (isRecent(_vert_pos_fuse_attempt_time_us, 1000000)) {
 		if (isRecent(_vert_vel_fuse_time_us, 1000000)) {
 			// If vertical position and velocity come from independent sensors then we can
 			// trust them more if they disagree with the IMU, but need to check that they agree
@@ -919,7 +919,7 @@ void Ekf::checkVerticalAccelerationHealth()
 				 _imu_sample_delayed.delta_vel_clipping[1] ||
 				 _imu_sample_delayed.delta_vel_clipping[2];
 	if (is_clipping &&_clip_counter < clip_count_limit) {
-			_clip_counter++;
+		_clip_counter++;
 	} else if (_clip_counter > 0) {
 		_clip_counter--;
 	}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -913,21 +913,21 @@ void Ekf::checkVerticalAccelerationHealth()
 		}
 	}
 
-	// Check for > 50% clipping affected IMU samples within the past 1 second
+	// Check for more than 50% clipping affected IMU samples within the past 1 second
 	const uint16_t clip_count_limit = 1000 / FILTER_UPDATE_PERIOD_MS;
-	if (_imu_sample_delayed.delta_vel_clipping[0] ||
-	    _imu_sample_delayed.delta_vel_clipping[1] ||
-	    _imu_sample_delayed.delta_vel_clipping[2]) {
-		if (_clip_counter < clip_count_limit) {
+	const bool is_clipping = _imu_sample_delayed.delta_vel_clipping[0] ||
+				 _imu_sample_delayed.delta_vel_clipping[1] ||
+				 _imu_sample_delayed.delta_vel_clipping[2];
+	if (is_clipping &&_clip_counter < clip_count_limit) {
 			_clip_counter++;
-		}
 	} else if (_clip_counter > 0) {
 		_clip_counter--;
 	}
+	const bool is_clipping_frequently = _clip_counter > 0;
 
 	// if vertical velocity and position are independent and agree, then do not require evidence of clipping if
 	// innovations are large
-	const bool bad_vert_accel = (are_vertical_pos_and_vel_independant || _clip_counter > 0) &&
+	const bool bad_vert_accel = (are_vertical_pos_and_vel_independant || is_clipping_frequently) &&
 				is_inertial_nav_falling;
 
 	if (bad_vert_accel) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -927,7 +927,7 @@ void Ekf::checkVerticalAccelerationHealth()
 
 	// if vertical velocity and position are independent and agree, then do not require evidence of clipping if
 	// innovations are large
-	const bool bad_vert_accel = (are_vertical_pos_and_vel_independant || _clip_counter > clip_count_limit / 2) &&
+	const bool bad_vert_accel = (are_vertical_pos_and_vel_independant || _clip_counter > 0) &&
 				is_inertial_nav_falling;
 
 	if (bad_vert_accel) {

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -152,7 +152,7 @@ void Ekf::predictCovariance()
 
 		// When on ground, only consider an accel bias observable if aligned with the gravity vector
 		const bool is_bias_observable = (fabsf(_R_to_earth(2, index)) > 0.8f) || _control_status.flags.in_air;
-		const bool do_inhibit_axis = do_inhibit_all_axes || !is_bias_observable;
+		const bool do_inhibit_axis = do_inhibit_all_axes || !is_bias_observable || _imu_sample_delayed.delta_vel_clipping[index];
 
 		if (do_inhibit_axis) {
 			// store the bias state variances to be reinstated later

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -391,8 +391,8 @@ private:
 
 	Vector3f _last_vel_obs;			///< last velocity observation (m/s)
 	Vector2f _last_fail_hvel_innov;		///< last failed horizontal velocity innovation (m/s)**2
-	float _vert_pos_innov_ratio;		///< standard deviation of vertical position innovation
-	uint64_t _vert_pos_fuse_time_us;	///< last system time in usec vertical position measurement fuson was attempted
+	float _vert_pos_innov_ratio;		///< vertical position innovation divided by estimated standard deviation of innovation
+	uint64_t _vert_pos_fuse_attempt_time_us;	///< last system time in usec vertical position measurement fuson was attempted
 	float _vert_vel_innov_ratio;		///< standard deviation of vertical velocity innovation
 	uint64_t _vert_vel_fuse_time_us;	///< last system time in usec time vertical velocity measurement fuson was attempted
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -390,7 +390,11 @@ private:
 	Vector3f _delta_angle_bias_var_accum;	///< kahan summation algorithm accumulator for delta angle bias variance
 
 	Vector3f _last_vel_obs;			///< last velocity observation (m/s)
-	Vector2f _last_fail_hvel_innov;	///< last failed horizontal velocity innovation (m/s)**2
+	Vector2f _last_fail_hvel_innov;		///< last failed horizontal velocity innovation (m/s)**2
+	float _vert_pos_innov_ratio;		///< standard deviation of vertical position innovation
+	uint64_t _vert_pos_fuse_time_us;	///< last system time in usec vertical position measurement fuson was attempted
+	float _vert_vel_innov_ratio;		///< standard deviation of vertical velocity innovation
+	uint64_t _vert_vel_fuse_time_us;	///< last system time in usec time vertical velocity measurement fuson was attempted
 
 	Vector3f _gps_vel_innov;	///< GPS velocity innovations (m/sec)
 	Vector3f _gps_vel_innov_var;	///< GPS velocity innovation variances ((m/sec)**2)
@@ -510,6 +514,8 @@ private:
 	// imu fault status
 	uint64_t _time_bad_vert_accel{0};	///< last time a bad vertical accel was detected (uSec)
 	uint64_t _time_good_vert_accel{0};	///< last time a good vertical accel was detected (uSec)
+	bool _bad_vert_accel_detected{false};	///< true when bad vertical accelerometer data has been detected
+	uint16_t _clip_counter{0};		///< counter that increments when clipping ad decrements when not
 
 	// variables used to control range aid functionality
 	bool _is_range_aid_suitable{false};	///< true when range finder can be used in flight as the height reference instead of the primary height sensor

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -151,12 +151,12 @@ bool Ekf::fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate
 	innov_var(2) = P(9, 9) + obs_var(2);
 	test_ratio(1) = sq(innov(2)) / (sq(innov_gate(1)) * innov_var(2));
 	_vert_pos_innov_ratio = innov(2) / sqrtf(innov_var(2));
-	_vert_pos_fuse_time_us = _time_last_imu;
+	_vert_pos_fuse_attempt_time_us = _time_last_imu;
 	bool innov_check_pass = test_ratio(1) <= 1.0f;
 
 	// if there is bad vertical acceleration data, then don't reject measurement,
 	// but limit innovation to prevent spikes that could destabilise the filter
-	float innovation = innov(2);
+	float innovation;
 	if (_bad_vert_accel_detected && !innov_check_pass) {
 		const float innov_limit = innov_gate(1) * sqrtf(innov_var(2));
 		innovation = math::constrain(innov(2), -innov_limit, innov_limit);

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -85,7 +85,7 @@ bool Ekf::fuseVerticalVelocity(const Vector3f &innov, const Vector2f &innov_gate
 
 	// if there is bad vertical acceleration data, then don't reject measurement,
 	// but limit innovation to prevent spikes that could destabilise the filter
-	float innovation = innov(2);
+	float innovation;
 	if (_bad_vert_accel_detected && !innov_check_pass) {
 		const float innov_limit = innov_gate(1) * sqrtf(innov_var(2));
 		innovation = math::constrain(innov(2), -innov_limit, innov_limit);

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -79,7 +79,8 @@ bool Ekf::fuseVerticalVelocity(const Vector3f &innov, const Vector2f &innov_gate
 
 	innov_var(2) = P(6, 6) + obs_var(2);
 	test_ratio(1) = sq(innov(2)) / (sq(innov_gate(1)) * innov_var(2));
-
+	_vert_vel_innov_ratio = innov(2) / sqrtf(innov_var(2));
+	_vert_vel_fuse_time_us = _time_last_imu;
 	const bool innov_check_pass = (test_ratio(1) <= 1.0f);
 
 	if (innov_check_pass) {
@@ -138,13 +139,13 @@ bool Ekf::fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate
 
 	innov_var(2) = P(9, 9) + obs_var(2);
 	test_ratio(1) = sq(innov(2)) / (sq(innov_gate(1)) * innov_var(2));
-
+	_vert_pos_innov_ratio = innov(2) / sqrtf(innov_var(2));
+	_vert_pos_fuse_time_us = _time_last_imu;
 	const bool innov_check_pass = test_ratio(1) <= 1.0f;
 
 	if (innov_check_pass) {
 		_time_last_hgt_fuse = _time_last_imu;
 		_innov_check_fail_status.flags.reject_ver_pos = false;
-
 		fuseVelPosHeight(innov(2), innov_var(2), 5);
 
 		return true;

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -81,13 +81,24 @@ bool Ekf::fuseVerticalVelocity(const Vector3f &innov, const Vector2f &innov_gate
 	test_ratio(1) = sq(innov(2)) / (sq(innov_gate(1)) * innov_var(2));
 	_vert_vel_innov_ratio = innov(2) / sqrtf(innov_var(2));
 	_vert_vel_fuse_time_us = _time_last_imu;
-	const bool innov_check_pass = (test_ratio(1) <= 1.0f);
+	bool innov_check_pass = (test_ratio(1) <= 1.0f);
+
+	// if there is bad vertical acceleration data, then don't reject measurement,
+	// but limit innovation to prevent spikes that could destabilise the filter
+	float innovation = innov(2);
+	if (_bad_vert_accel_detected && !innov_check_pass) {
+		const float innov_limit = innov_gate(1) * sqrtf(innov_var(2));
+		innovation = math::constrain(innov(2), -innov_limit, innov_limit);
+		innov_check_pass = true;
+	} else {
+		innovation = innov(2);
+	}
 
 	if (innov_check_pass) {
 		_time_last_ver_vel_fuse = _time_last_imu;
 		_innov_check_fail_status.flags.reject_ver_vel = false;
 
-		fuseVelPosHeight(innov(2), innov_var(2), 2);
+		fuseVelPosHeight(innovation, innov_var(2), 2);
 
 		return true;
 
@@ -141,12 +152,23 @@ bool Ekf::fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate
 	test_ratio(1) = sq(innov(2)) / (sq(innov_gate(1)) * innov_var(2));
 	_vert_pos_innov_ratio = innov(2) / sqrtf(innov_var(2));
 	_vert_pos_fuse_time_us = _time_last_imu;
-	const bool innov_check_pass = test_ratio(1) <= 1.0f;
+	bool innov_check_pass = test_ratio(1) <= 1.0f;
+
+	// if there is bad vertical acceleration data, then don't reject measurement,
+	// but limit innovation to prevent spikes that could destabilise the filter
+	float innovation = innov(2);
+	if (_bad_vert_accel_detected && !innov_check_pass) {
+		const float innov_limit = innov_gate(1) * sqrtf(innov_var(2));
+		innovation = math::constrain(innov(2), -innov_limit, innov_limit);
+		innov_check_pass = true;
+	} else {
+		innovation = innov(2);
+	}
 
 	if (innov_check_pass) {
 		_time_last_hgt_fuse = _time_last_imu;
 		_innov_check_fail_status.flags.reject_ver_pos = false;
-		fuseVelPosHeight(innov(2), innov_var(2), 5);
+		fuseVelPosHeight(innovation, innov_var(2), 5);
 
 		return true;
 


### PR DESCRIPTION
Improvement in response to Issue #835 

Extends early reset to recover from bad vibration induced loss of height estimation to includes sensor combinations other than Baro for height and GPS for vertical velocity.

When height and vertical velocity sensing iis from the same sensor (GPS or EV), IMU clipping is used to adjudicate.
