### PR TITLE
EKF: add const reference getters for status flags

### DIFF
--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -311,9 +311,14 @@ public:
 
 	// get EKF mode status
 	void get_control_mode(uint32_t *val) { *val = _control_status.value; }
+	const decltype(filter_control_status_u::flags) &control_status_flags() const { return _control_status.flags; }
+	const decltype(filter_control_status_u::flags) &control_status_prev_flags() const { return _control_status_prev.flags; }
 
 	// get EKF internal fault status
 	void get_filter_fault_status(uint16_t *val) { *val = _fault_status.value; }
+	const decltype(fault_status_u::flags) &fault_status_flags() const { return _fault_status.flags; }
+
+	const decltype(innovation_fault_status_u::flags) &innov_check_fail_status_flags() const { return _innov_check_fail_status.flags; }
 
 	bool isVehicleAtRest() const { return _control_status.flags.vehicle_at_rest; }
 


### PR DESCRIPTION
This is for convenient usage outside of ECL.

### Before
``` C++
		filter_control_status_u control_status;
		_ekf.get_control_mode(&control_status.value);

		_preflt_checker.setUsingGpsAiding(control_status.flags.gps);
```

### After
``` C++
		_preflt_checker.setUsingGpsAiding(_ekf.control_status_flags().gps);
```