### PR TITLE
Auto update change indication

### DIFF
--- a/.github/workflows/functional_change_indicator.yml
+++ b/.github/workflows/functional_change_indicator.yml
@@ -1,21 +1,19 @@
 name: Change Indicator
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: pull_request
 
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
     container: px4io/px4-dev-base-focal:2020-09-14
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.3.1
+    - name: checkout newest version of branch
+      run: |
+        git fetch origin pull/${{github.event.pull_request.number}}/head:${{github.head_ref}}
+        git checkout ${GITHUB_HEAD_REF}
     - name: main test
       run: make test
-    - name: Check if there exists diff
-      run: git diff --exit-code
+    - name: Check if there is a functional change
+      run:  git diff --exit-code
       working-directory: test/change_indication

--- a/.github/workflows/update_change_indicator.yml
+++ b/.github/workflows/update_change_indicator.yml
@@ -1,0 +1,27 @@
+name: Change Indicator
+
+on: push
+
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-base-focal:2020-09-14
+    env:
+      GIT_COMMITTER_EMAIL: bot@px4.io
+      GIT_COMMITTER_NAME: PX4BuildBot
+    steps:
+    - uses: actions/checkout@v2.3.1
+    - name: main test updates change indication files
+      run: make test
+    - name: Check if there exists diff and save result in variable
+      run:  echo "CHANGE_INDICATED=$(git diff --exit-code --output=/dev/null || echo $?)" >> $GITHUB_ENV
+      working-directory: test/change_indication
+    - name: auto-commit any changes to change indication
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: '[AUTO COMMIT] update change indication'
+        commit_user_name: ${GIT_COMMITTER_NAME}
+        commit_user_email: ${GIT_COMMITTER_EMAIL}
+    - if: ${{env.CHANGE_INDICATED}}
+      name: if there is a functional change, fail check
+      run: exit 1

--- a/test/change_indication/iris_gps.csv
+++ b/test/change_indication/iris_gps.csv
@@ -1,3 +1,4 @@
+
 Timestamp,state[0],state[1],state[2],state[3],state[4],state[5],state[6],state[7],state[8],state[9],state[10],state[11],state[12],state[13],state[14],state[15],state[16],state[17],state[18],state[19],state[20],state[21],state[22],state[23],variance[0],variance[1],variance[2],variance[3],variance[4],variance[5],variance[6],variance[7],variance[8],variance[9],variance[10],variance[11],variance[12],variance[13],variance[14],variance[15],variance[16],variance[17],variance[18],variance[19],variance[20],variance[21],variance[22],variance[23]
 15000,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 85000,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0

--- a/test/change_indication/iris_gps.csv
+++ b/test/change_indication/iris_gps.csv
@@ -1,4 +1,3 @@
-
 Timestamp,state[0],state[1],state[2],state[3],state[4],state[5],state[6],state[7],state[8],state[9],state[10],state[11],state[12],state[13],state[14],state[15],state[16],state[17],state[18],state[19],state[20],state[21],state[22],state[23],variance[0],variance[1],variance[2],variance[3],variance[4],variance[5],variance[6],variance[7],variance[8],variance[9],variance[10],variance[11],variance[12],variance[13],variance[14],variance[15],variance[16],variance[17],variance[18],variance[19],variance[20],variance[21],variance[22],variance[23]
 15000,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 85000,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0


### PR DESCRIPTION
The change indication is a nice tool to check if a proposed change does not introduce a functional change. It only covers limited scenarios, so it is by no means sufficient proof that there is no functional change introduced. The change indication requires to update certain csv files each time a functional change is made. This is a very delicate process, as the local build environment (compiler version, ...) has to match the CI build environment closely. Using docker containers is an alternative to produce correct change indication files. However, this involves many steps and is laborious. 

This PR adds another Github action, that updates the change indication on push, commits it, and pushes it to the remote branch.  The commit has the name `[AUTO COMMIT] update change indication`.  As it is triggered by push, when creating a pull request from a fork, it will run the check on the fork and update the fork branch with the new change indication. The original change indication in the `functional_change_indicator.yaml` will only be run on the pull request and does not update the change indication.

In case a functional change happens and the pull request is created almost immediately after pushing the branch, the pull request change_indicator check can fail, as it does not have the change indication update. In this case the check can be rerun after the automatic commit is pushed and will then pass.