### PR TITLE
Fix GPS loss dead reckoning behaviour

### DIFF
--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -158,6 +158,7 @@ void Ekf::fuseAirspeed()
 
 	if (is_fused) {
 		_time_last_arsp_fuse = _time_last_imu;
+		_control_status.flags.fuse_aspd = true;
 	}
 }
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1215,7 +1215,7 @@ void Ekf::controlBetaFusion()
 
 void Ekf::controlDragFusion()
 {
-	if (_params.fusion_mode & MASK_USE_DRAG &&
+	if ((_params.fusion_mode & MASK_USE_DRAG) &&
 	    !_using_synthetic_position &&
 	    _control_status.flags.in_air &&
 	    !_mag_inhibit_yaw_reset_req) {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -195,7 +195,13 @@ public:
 	// and have not started using synthetic position observations to constrain drift
 	bool global_position_is_valid() const
 	{
-		return (_NED_origin_initialised && !_deadreckon_time_exceeded && !_using_synthetic_position);
+		return (_NED_origin_initialised && local_position_is_valid());
+	}
+
+	// return true if the local position estimate is valid
+	bool local_position_is_valid() const
+	{
+		return (!_deadreckon_time_exceeded && !_using_synthetic_position);
 	}
 
 	bool isTerrainEstimateValid() const { return _hagl_valid; };

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -598,8 +598,6 @@ void EstimatorInterface::printBufferAllocationFailed(const char *buffer_name)
 
 void EstimatorInterface::print_status()
 {
-	ECL_INFO("local position valid: %s", local_position_is_valid() ? "yes" : "no");
-
 	ECL_INFO("imu buffer: %d (%d Bytes)", _imu_buffer.get_length(), _imu_buffer.get_total_size());
 	ECL_INFO("gps buffer: %d (%d Bytes)", _gps_buffer.get_length(), _gps_buffer.get_total_size());
 	ECL_INFO("mag buffer: %d (%d Bytes)", _mag_buffer.get_length(), _mag_buffer.get_total_size());

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -158,9 +158,6 @@ public:
 
 	int getNumberOfActiveHorizontalAidingSources() const;
 
-	// return true if the local position estimate is valid
-	bool local_position_is_valid() const { return local_position_is_valid(); }
-
 	// return true if the EKF is dead reckoning the position using inertial data only
 	bool inertial_dead_reckoning() const { return _is_dead_reckoning; }
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -159,7 +159,7 @@ public:
 	int getNumberOfActiveHorizontalAidingSources() const;
 
 	// return true if the local position estimate is valid
-	bool local_position_is_valid() const { return !_deadreckon_time_exceeded; }
+	bool local_position_is_valid() const { return local_position_is_valid(); }
 
 	// return true if the EKF is dead reckoning the position using inertial data only
 	bool inertial_dead_reckoning() const { return _is_dead_reckoning; }


### PR DESCRIPTION
During SITL testing with gazebo_plane it was observed that if sideslip fusion was disabled by setting EKF2_FUSE_BETA=0 and the GPS stopped by first setting the parameter SYS_FAILURE_EN = 1 followed by pxh> failure gps off, then the following occurred:

The vehicle_local_position.valid_xy flag periodically goes true true and wind states experience large variations after the EKF had reverted back to a non-position estimation mode - see below.

![Screen Shot 2020-12-03 at 9 03 26 pm](https://user-images.githubusercontent.com/3596952/100994733-02f19a80-35ab-11eb-8cdc-cfbd6fb105a2.png)
 
These changes fix this by ensuring that a valid local position can never be reported true and the wind states and covariances are deactivated  if the EKF is in a non-position mode - see below
 
![Screen Shot 2020-12-03 at 9 01 13 pm](https://user-images.githubusercontent.com/3596952/100994432-af7f4c80-35aa-11eb-947e-0194b426b095.png)

Note that setting EKF2_FUSE_BETA = 1 is recommended for fixed wing flight in the majority of applications due to the extended dead-reckoning in excess of 5 minutes achievable after GPS loss.

@sfuhrer FYI
