### PR TITLE
Fix GPS altitude variance computation

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1103,11 +1103,7 @@ void Ekf::controlHeightFusion()
 			Vector3f gps_hgt_obs_var;
 			// vertical position innovation - gps measurement has opposite sign to earth z axis
 			_gps_pos_innov(2) = _state.pos(2) + _gps_sample_delayed.hgt - _gps_alt_ref - _hgt_sensor_offset;
-			// observation variance - receiver defined and parameter limited
-			// use scaled horizontal position accuracy assuming typical ratio of VDOP/HDOP
-			const float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
-			const float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
-			gps_hgt_obs_var(2) = sq(1.5f * math::constrain(_gps_sample_delayed.vacc, lower_limit, upper_limit));
+			gps_hgt_obs_var(2) = getGpsAltVar();
 			// innovation gate size
 			gps_hgt_innov_gate(1) = fmaxf(_params.baro_innov_gate, 1.0f);
 			// fuse height information

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1103,7 +1103,7 @@ void Ekf::controlHeightFusion()
 			Vector3f gps_hgt_obs_var;
 			// vertical position innovation - gps measurement has opposite sign to earth z axis
 			_gps_pos_innov(2) = _state.pos(2) + _gps_sample_delayed.hgt - _gps_alt_ref - _hgt_sensor_offset;
-			gps_hgt_obs_var(2) = getGpsAltVar();
+			gps_hgt_obs_var(2) = getGpsHeightVariance();
 			// innovation gate size
 			gps_hgt_innov_gate(1) = fmaxf(_params.baro_innov_gate, 1.0f);
 			// fuse height information

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -74,7 +74,7 @@ void Ekf::initialiseCovariance()
 		P(9,9) = sq(fmaxf(_params.range_noise, 0.01f));
 
 	} else if (_control_status.flags.gps_hgt) {
-		P(9,9) = getGpsAltVar();
+		P(9,9) = getGpsHeightVariance();
 
 	} else {
 		P(9,9) = sq(fmaxf(_params.baro_noise, 0.01f));

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -74,9 +74,7 @@ void Ekf::initialiseCovariance()
 		P(9,9) = sq(fmaxf(_params.range_noise, 0.01f));
 
 	} else if (_control_status.flags.gps_hgt) {
-		float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
-		float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
-		P(9,9) = sq(1.5f * math::constrain(_gps_sample_delayed.vacc, lower_limit, upper_limit));
+		P(9,9) = getGpsAltVar();
 
 	} else {
 		P(9,9) = sq(fmaxf(_params.baro_noise, 0.01f));

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -852,7 +852,7 @@ private:
 	void updateBaroHgtOffset();
 
 	// return an estimation of the GPS altitude variance
-	float getGpsAltVar();
+	float getGpsHeightVariance();
 
 	// calculate the measurement variance for the optical flow sensor
 	float calcOptFlowMeasVar();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -851,6 +851,9 @@ private:
 
 	void updateBaroHgtOffset();
 
+	// return an estimation of the GPS altitude variance
+	float getGpsAltVar();
+
 	// calculate the measurement variance for the optical flow sensor
 	float calcOptFlowMeasVar();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1247,8 +1247,9 @@ void Ekf::updateBaroHgtOffset()
 float Ekf::getGpsHeightVariance()
 {
 	// observation variance - receiver defined and parameter limited
-	const float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
-	const float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
+	// use 1.5 as a typical ratio of vacc/hacc
+	const float lower_limit = fmaxf(1.5f * _params.gps_pos_noise, 0.01f);
+	const float upper_limit = fmaxf(1.5f * _params.pos_noaid_noise, lower_limit);
 	const float gps_alt_var = sq(math::constrain(_gps_sample_delayed.vacc, lower_limit, upper_limit));
 	return gps_alt_var;
 }

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1244,6 +1244,16 @@ void Ekf::updateBaroHgtOffset()
 	}
 }
 
+float Ekf::getGpsAltVar()
+{
+	// observation variance - receiver defined and parameter limited
+	// use scaled horizontal position accuracy assuming typical ratio of VDOP/HDOP
+	const float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
+	const float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
+	const float gps_alt_var = sq(1.5f * math::constrain(_gps_sample_delayed.vacc, lower_limit, upper_limit));
+	return gps_alt_var;
+}
+
 Vector3f Ekf::getVisionVelocityInEkfFrame() const
 {
 	Vector3f vel;

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1247,10 +1247,9 @@ void Ekf::updateBaroHgtOffset()
 float Ekf::getGpsAltVar()
 {
 	// observation variance - receiver defined and parameter limited
-	// use scaled horizontal position accuracy assuming typical ratio of VDOP/HDOP
 	const float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
 	const float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
-	const float gps_alt_var = sq(1.5f * math::constrain(_gps_sample_delayed.vacc, lower_limit, upper_limit));
+	const float gps_alt_var = sq(math::constrain(_gps_sample_delayed.vacc, lower_limit, upper_limit));
 	return gps_alt_var;
 }
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1244,7 +1244,7 @@ void Ekf::updateBaroHgtOffset()
 	}
 }
 
-float Ekf::getGpsAltVar()
+float Ekf::getGpsHeightVariance()
 {
 	// observation variance - receiver defined and parameter limited
 	const float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);


### PR DESCRIPTION
Review commit-by-commit.

For some reason, the GPS position variance was fused with an accuracy of `1.5 x reported vertical position accuracy` (introduced here: https://github.com/PX4/PX4-ECL/commit/6b2e2dba909a44430dc3879e73e990231fcc2206#diff-4fbcbe3d9e3bd3fad671899aab33b57ee060d253a71a7c45e9acb78c2d297d22R125-R128).

To me, it seems to be from a copy-pasta of the GPS vertical speed fusion, where the vertical speed accuracy needs to be computed as `1.5 x reported horizontal speed accuracy`. (https://github.com/PX4/PX4-ECL/blob/fbf67bdef99f6033ce6c1fb6736cd7bf67020602/EKF/control.cpp#L698-L699).