### PR TITLE
EKF: Treat combined sideslip and airspeed as a horizontal aiding source

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -722,7 +722,7 @@ void Ekf::controlGpsFusion()
 		// Handle the case where we are fusing another position source along GPS,
 		// stop waiting for GPS after 1 s of lost signal
 		stopGpsFusion();
-		ECL_WARN_TIMESTAMPED("GPS data stopped, using only EV or OF");
+		ECL_WARN_TIMESTAMPED("GPS data stopped, using only EV, OF or air data" );
 	}
 }
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -548,9 +548,9 @@ int EstimatorInterface::getNumberOfActiveHorizontalAidingSources() const
 	       + int(_control_status.flags.opt_flow)
 	       + int(_control_status.flags.ev_pos)
 	       + int(_control_status.flags.ev_vel)
-		   // Combined airspeed and sideslip fusion allows sustained wind relative dead reckoning
-		   // and so is treated as a single aiding source.
-		   + int(_control_status.flags.fuse_aspd && _control_status.flags.fuse_beta);
+	       // Combined airspeed and sideslip fusion allows sustained wind relative dead reckoning
+	       // and so is treated as a single aiding source.
+	       + int(_control_status.flags.fuse_aspd && _control_status.flags.fuse_beta);
 }
 
 bool EstimatorInterface::isHorizontalAidingActive() const

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -547,7 +547,10 @@ int EstimatorInterface::getNumberOfActiveHorizontalAidingSources() const
 	return int(_control_status.flags.gps)
 	       + int(_control_status.flags.opt_flow)
 	       + int(_control_status.flags.ev_pos)
-	       + int(_control_status.flags.ev_vel);
+	       + int(_control_status.flags.ev_vel)
+		   // Combined airspeed and sideslip fusion allows sustained wind relative dead reckoning
+		   // and so is treated as a single aiding source.
+		   + int(_control_status.flags.fuse_aspd && _control_status.flags.fuse_beta);
 }
 
 bool EstimatorInterface::isHorizontalAidingActive() const


### PR DESCRIPTION
The combination of airspeed and sideslip fusion acts to constrain horizontal velocity drift with wind relative dead reckoning, however this was not being recognised in the code.  This change treats the combination of airspeed and sideslip fusion as an equivalent horizontal velocity aiding source and ensures the solution status velocity_horiz flag will remain true if a fixed wing aircraft with airspeed and sideslip fusion loses GPS.