### PR TITLE
rng height: reset to baro using common logic

### DIFF
--- a/EKF/Sensor.hpp
+++ b/EKF/Sensor.hpp
@@ -70,6 +70,12 @@ public:
 	 * and can be fused in the estimator
 	 */
 	virtual bool isDataHealthy() const = 0;
+
+	/*
+	 * return true if the sensor data rate is
+	 * stable and high enough
+	 */
+	virtual bool isRegularlySendingData() const = 0;
 };
 
 } // namespace sensor

--- a/EKF/sensor_range_finder.cpp
+++ b/EKF/sensor_range_finder.cpp
@@ -64,8 +64,11 @@ void SensorRangeFinder::updateValidity(uint64_t current_time_us)
 
 	if (isSampleOutOfDate(current_time_us) || !isDataContinuous()) {
 		_is_sample_valid = false;
+		_is_regularly_sending_data = false;
 		return;
 	}
+
+	_is_regularly_sending_data = true;
 
 	// Don't run the checks unless we have retrieved new data from the buffer
 	if (_is_sample_ready) {

--- a/EKF/sensor_range_finder.hpp
+++ b/EKF/sensor_range_finder.hpp
@@ -57,6 +57,7 @@ public:
 	void runChecks(uint64_t current_time_us, const matrix::Dcmf &R_to_earth);
 	bool isHealthy() const override { return _is_sample_valid; }
 	bool isDataHealthy() const override { return _is_sample_ready && _is_sample_valid; }
+	bool isRegularlySendingData() const override { return _is_regularly_sending_data; }
 
 	void setSample(const rangeSample &sample) {
 		_sample = sample;
@@ -115,6 +116,7 @@ private:
 
 	bool _is_sample_ready{};	///< true when new range finder data has fallen behind the fusion time horizon and is available to be fused
 	bool _is_sample_valid{};	///< true if range finder sample retrieved from buffer is valid
+	bool _is_regularly_sending_data{false}; ///< true if the interval between two samples is less than the maximum expected interval
 	uint64_t _time_last_valid_us{};	///< time the last range finder measurement was ready (uSec)
 
 	/*

--- a/test/test_EKF_fusionLogic.cpp
+++ b/test/test_EKF_fusionLogic.cpp
@@ -337,17 +337,26 @@ TEST_F(EkfFusionLogicTest, doRangeHeightFusion)
 	// WHEN: commanding range height and sending range data
 	_ekf_wrapper.setRangeHeight();
 	_sensor_simulator.startRangeFinder();
-	_sensor_simulator.runSeconds(2.5);
-
+	_sensor_simulator.runSeconds(2.5f);
 	// THEN: EKF should intend to fuse range height
 	EXPECT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
 
+	const float dt = 8e-3f;
+	for (int i = 0; i < 5; i++) {
+		_sensor_simulator.runSeconds(dt);
+		// THEN: EKF should intend to fuse range height, even if
+		// there is no new data at each EKF iteration (EKF rate > sensor rate)
+		EXPECT_TRUE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	}
+
 	// WHEN: stop sending range data
 	_sensor_simulator.stopRangeFinder();
-	_sensor_simulator.runSeconds(2.5);
+	_sensor_simulator.runSeconds(5.1);
 
 	// THEN: EKF should stop to intend to use range height
+	// and fall back to baro height
 	EXPECT_FALSE(_ekf_wrapper.isIntendingRangeHeightFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
 }
 
 TEST_F(EkfFusionLogicTest, doVisionHeightFusion)


### PR DESCRIPTION
The failsafe from rng height to baro height should occur after a reset
to baro triggered by the controlHeightSensorTimeouts function and not in
the fusion selector.

Until now, the EKF was fusing baro measurements between rng updates if
the range finder ODR was slower than the EKF update rate. This is not
the case anymore as the height reset occurs after 5 seconds.

The unit test has been extended to show this behavior.

fixes https://github.com/PX4/PX4-ECL/issues/958