### PR TITLE
remove ECL_{INFO,WARN,ERN}_TIMESTAMPED macros

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -339,8 +339,7 @@ void Ekf::controlExternalVisionFusion()
 
 		// Turn off EV fusion mode if no data has been received
 		stopEvFusion();
-		ECL_INFO_TIMESTAMPED("vision data stopped");
-
+		ECL_INFO("vision data stopped");
 	}
 }
 
@@ -555,7 +554,7 @@ void Ekf::controlGpsFusion()
 			if (_control_status.flags.ev_pos && !(_params.fusion_mode & MASK_ROTATE_EV)) {
 				resetHorizontalPosition();
 			}
-			ECL_WARN_TIMESTAMPED("GPS quality poor - stopping use");
+			ECL_WARN("GPS quality poor - stopping use");
 		}
 
 		// handle case where we are not currently using GPS, but need to align yaw angle using EKF-GSF before
@@ -656,7 +655,7 @@ void Ekf::controlGpsFusion()
 				resetVelocity();
 				resetHorizontalPosition();
 				_velpos_reset_request = false;
-				ECL_WARN_TIMESTAMPED("GPS fusion timeout - reset to GPS");
+				ECL_WARN("GPS fusion timeout - reset to GPS");
 
 				// Reset the timeout counters
 				_time_last_hor_pos_fuse = _time_last_imu;
@@ -717,12 +716,12 @@ void Ekf::controlGpsFusion()
 
 	} else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)10e6)) {
 		stopGpsFusion();
-		ECL_WARN_TIMESTAMPED("GPS data stopped");
+		ECL_WARN("GPS data stopped");
 	}  else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)1e6) && isOtherSourceOfHorizontalAidingThan(_control_status.flags.gps)) {
 		// Handle the case where we are fusing another position source along GPS,
 		// stop waiting for GPS after 1 s of lost signal
 		stopGpsFusion();
-		ECL_WARN_TIMESTAMPED("GPS data stopped, using only EV, OF or air data" );
+		ECL_WARN("GPS data stopped, using only EV, OF or air data" );
 	}
 }
 
@@ -1272,7 +1271,7 @@ void Ekf::controlFakePosFusion()
 				_fuse_hpos_as_odom = false;
 
 				if (_time_last_fake_pos != 0) {
-					ECL_WARN_TIMESTAMPED("stopping navigation");
+					ECL_WARN("stopping navigation");
 				}
 
 			}

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -968,7 +968,7 @@ void Ekf::fixCovarianceErrors(bool force_symmetry)
 
 			_time_acc_bias_check = _time_last_imu;
 			_fault_status.flags.bad_acc_bias = false;
-			ECL_WARN_TIMESTAMPED("invalid accel bias - covariance reset");
+			ECL_WARN("invalid accel bias - covariance reset");
 
 		} else if (force_symmetry) {
 			// ensure the covariance values are symmetrical

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -65,14 +65,14 @@ void Ekf::resetVelocity()
 
 void Ekf::resetVelocityToGps()
 {
-	ECL_INFO_TIMESTAMPED("reset velocity to GPS");
+	ECL_INFO("reset velocity to GPS");
 	resetVelocityTo(_gps_sample_delayed.vel);
 	P.uncorrelateCovarianceSetVariance<3>(4, sq(_gps_sample_delayed.sacc));
 }
 
 void Ekf::resetHorizontalVelocityToOpticalFlow()
 {
-	ECL_INFO_TIMESTAMPED("reset velocity to flow");
+	ECL_INFO("reset velocity to flow");
 	// constrain height above ground to be above minimum possible
 	const float heightAboveGndEst = fmaxf((_terrain_vpos - _state.pos(2)), _params.rng_gnd_clearance);
 
@@ -102,14 +102,14 @@ void Ekf::resetHorizontalVelocityToOpticalFlow()
 
 void Ekf::resetVelocityToVision()
 {
-	ECL_INFO_TIMESTAMPED("reset to vision velocity");
+	ECL_INFO("reset to vision velocity");
 	resetVelocityTo(getVisionVelocityInEkfFrame());
 	P.uncorrelateCovarianceSetVariance<3>(4, getVisionVelocityVarianceInEkfFrame());
 }
 
 void Ekf::resetHorizontalVelocityToZero()
 {
-	ECL_INFO_TIMESTAMPED("reset velocity to zero");
+	ECL_INFO("reset velocity to zero");
 	// Used when falling back to non-aiding mode of operation
 	resetHorizontalVelocityTo(Vector2f{0.f, 0.f});
 	P.uncorrelateCovarianceSetVariance<2>(4, 25.0f);
@@ -167,7 +167,7 @@ void Ekf::resetHorizontalPosition()
 		resetHorizontalPositionToVision();
 
 	} else if (_control_status.flags.opt_flow) {
-		ECL_INFO_TIMESTAMPED("reset position to last known position");
+		ECL_INFO("reset position to last known position");
 
 		if (!_control_status.flags.in_air) {
 			// we are likely starting OF for the first time so reset the horizontal position
@@ -181,7 +181,7 @@ void Ekf::resetHorizontalPosition()
 		P.uncorrelateCovarianceSetVariance<2>(7, 0.0f);
 
 	} else {
-		ECL_INFO_TIMESTAMPED("reset position to last known position");
+		ECL_INFO("reset position to last known position");
 		// Used when falling back to non-aiding mode of operation
 		resetHorizontalPositionTo(_last_known_posNE);
 		P.uncorrelateCovarianceSetVariance<2>(7, sq(_params.pos_noaid_noise));
@@ -190,14 +190,14 @@ void Ekf::resetHorizontalPosition()
 
 void Ekf::resetHorizontalPositionToGps()
 {
-	ECL_INFO_TIMESTAMPED("reset position to GPS");
+	ECL_INFO("reset position to GPS");
 	resetHorizontalPositionTo(_gps_sample_delayed.pos);
 	P.uncorrelateCovarianceSetVariance<2>(7, sq(_gps_sample_delayed.hacc));
 }
 
 void Ekf::resetHorizontalPositionToVision()
 {
-	ECL_INFO_TIMESTAMPED("reset position to ev position");
+	ECL_INFO("reset position to ev position");
 	Vector3f _ev_pos = _ev_sample_delayed.pos;
 
 	if (_params.fusion_mode & MASK_ROTATE_EV) {
@@ -405,12 +405,12 @@ bool Ekf::realignYawGPS()
 
 	// correct yaw angle using GPS ground course if compass yaw bad or yaw is previously not aligned
 	if (badMagYaw || !_control_status.flags.yaw_align) {
-		ECL_WARN_TIMESTAMPED("bad yaw, using GPS course");
+		ECL_WARN("bad yaw, using GPS course");
 
 		// declare the magnetometer as failed if a bad yaw has occurred more than once
 		if (_control_status.flags.mag_aligned_in_flight && (_num_bad_flight_yaw_events >= 2)
 		    && !_control_status.flags.mag_fault) {
-			ECL_WARN_TIMESTAMPED("stopping mag use");
+			ECL_WARN("stopping mag use");
 			_control_status.flags.mag_fault = true;
 		}
 
@@ -1385,7 +1385,7 @@ void Ekf::startGpsFusion()
 		resetVelocityToGps();
 	}
 
-	ECL_INFO_TIMESTAMPED("starting GPS fusion");
+	ECL_INFO("starting GPS fusion");
 	_control_status.flags.gps = true;
 }
 
@@ -1430,14 +1430,14 @@ void Ekf::startEvPosFusion()
 {
 	_control_status.flags.ev_pos = true;
 	resetHorizontalPosition();
-	ECL_INFO_TIMESTAMPED("starting vision pos fusion");
+	ECL_INFO("starting vision pos fusion");
 }
 
 void Ekf::startEvVelFusion()
 {
 	_control_status.flags.ev_vel = true;
 	resetVelocity();
-	ECL_INFO_TIMESTAMPED("starting vision vel fusion");
+	ECL_INFO("starting vision vel fusion");
 }
 
 void Ekf::startEvYawFusion()
@@ -1458,7 +1458,7 @@ void Ekf::startEvYawFusion()
 	stopMagHdgFusion();
 	stopMag3DFusion();
 
-	ECL_INFO_TIMESTAMPED("starting vision yaw fusion");
+	ECL_INFO("starting vision yaw fusion");
 }
 
 void Ekf::stopEvFusion()
@@ -1577,13 +1577,13 @@ bool Ekf::resetYawToEKFGSF()
 	_control_status.flags.yaw_align = true;
 
 	if (_params.mag_fusion_type == MAG_FUSE_TYPE_NONE) {
-		ECL_INFO_TIMESTAMPED("Yaw aligned using IMU and GPS");
+		ECL_INFO("Yaw aligned using IMU and GPS");
 
 	} else {
 		// stop using the magnetometer in the main EKF otherwise it's fusion could drag the yaw around
 		// and cause another navigation failure
 		_control_status.flags.mag_fault = true;
-		ECL_INFO_TIMESTAMPED("Emergency yaw reset - mag use stopped");
+		ECL_INFO("Emergency yaw reset - mag use stopped");
 	}
 
 	return true;

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -109,7 +109,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 			startGpsHgtFusion();
 		}
 
-		ECL_INFO_TIMESTAMPED("GPS checks passed");
+		ECL_INFO("GPS checks passed");
 
 	} else if (!_NED_origin_initialised) {
 		// a rough 2D fix is still sufficient to lookup declination

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -128,7 +128,7 @@ void Ekf::fuseGpsYaw()
 
 		// we reinitialise the covariance matrix and abort this fusion step
 		initialiseCovariance();
-		ECL_ERR_TIMESTAMPED("GPS yaw numerical error - covariance reset");
+		ECL_ERR("GPS yaw numerical error - covariance reset");
 		return;
 	}
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -607,7 +607,7 @@ void Ekf::updateQuaternion(const float innovation, const float variance, const f
 
 		// we reinitialise the covariance matrix and abort this fusion step
 		initialiseCovariance();
-		ECL_ERR_TIMESTAMPED("mag yaw fusion numerical error - covariance reset");
+		ECL_ERR("mag yaw fusion numerical error - covariance reset");
 		return;
 	}
 

--- a/ecl.h
+++ b/ecl.h
@@ -51,16 +51,6 @@ using ecl_abstime = hrt_abstime;
 #define ECL_WARN PX4_WARN
 #define ECL_ERR	 PX4_ERR
 
-#if defined(__PX4_POSIX)
-#define ECL_INFO_TIMESTAMPED(X) PX4_INFO("%llu: " X, (unsigned long long)_imu_sample_delayed.time_us)
-#define ECL_WARN_TIMESTAMPED(X) PX4_WARN("%llu: " X, (unsigned long long)_imu_sample_delayed.time_us)
-#define ECL_ERR_TIMESTAMPED(X) PX4_ERR("%llu: " X, (unsigned long long)_imu_sample_delayed.time_us)
-#else
-#define ECL_INFO_TIMESTAMPED PX4_INFO
-#define ECL_WARN_TIMESTAMPED PX4_WARN
-#define ECL_ERR_TIMESTAMPED PX4_ERR
-#endif
-
 #elif defined(__PAPARAZZI)
 
 #include "std.h"
@@ -73,9 +63,6 @@ using ecl_abstime = uint64_t;
 #define ECL_INFO(...)
 #define ECL_WARN(...)
 #define ECL_ERR(...)
-#define ECL_INFO_TIMESTAMPED PX4_INFO
-#define ECL_WARN_TIMESTAMPED PX4_WARN
-#define ECL_ERR_TIMESTAMPED PX4_ERR
 
 #else
 
@@ -90,10 +77,6 @@ using ecl_abstime = uint64_t;
 #define ECL_INFO(X, ...) printf(X "\n", ##__VA_ARGS__)
 #define ECL_WARN(X, ...) fprintf(stderr, X "\n", ##__VA_ARGS__)
 #define ECL_ERR(X, ...) fprintf(stderr, X "\n", ##__VA_ARGS__)
-
-#define ECL_INFO_TIMESTAMPED(X) ECL_INFO("%llu: " X, (unsigned long long)_imu_sample_delayed.time_us)
-#define ECL_WARN_TIMESTAMPED(X) ECL_WARN("%llu: " X, (unsigned long long)_imu_sample_delayed.time_us)
-#define ECL_ERR_TIMESTAMPED(X) ECL_ERR("%llu: " X, (unsigned long long)_imu_sample_delayed.time_us)
 
 #endif /* PX4_POSIX || PX4_NUTTX */
 


### PR DESCRIPTION
@kamilritz can we revisit what you wanted here? We already have mechanisms to print these messages timestamped (debug builds or similar). The mix of timestamped and non-timestamped messages is a bit weird. Also note that in log files the messages are timestamped.

