### PR TITLE
EKF: Fix reporting of non position mode innovation test levels

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -300,7 +300,7 @@ void Ekf::controlExternalVisionFusion()
 			// innovation gate size
 			ev_pos_innov_gates(0) = fmaxf(_params.ev_pos_innov_gate, 1.0f);
 
-			fuseHorizontalPosition(_ev_pos_innov, ev_pos_innov_gates, ev_pos_obs_var, _ev_pos_innov_var, _ev_pos_test_ratio, false);
+			fuseHorizontalPosition(_ev_pos_innov, ev_pos_innov_gates, ev_pos_obs_var, _ev_pos_innov_var, _ev_pos_test_ratio);
 		}
 
 		// determine if we should use the velocity observations
@@ -712,7 +712,7 @@ void Ekf::controlGpsFusion()
 			// fuse GPS measurement
 			fuseHorizontalVelocity(_gps_vel_innov, gps_vel_innov_gates,gps_vel_obs_var, _gps_vel_innov_var, _gps_vel_test_ratio);
 			fuseVerticalVelocity(_gps_vel_innov, gps_vel_innov_gates, gps_vel_obs_var, _gps_vel_innov_var, _gps_vel_test_ratio);
-			fuseHorizontalPosition(_gps_pos_innov, gps_pos_innov_gates, gps_pos_obs_var, _gps_pos_innov_var, _gps_pos_test_ratio, false);
+			fuseHorizontalPosition(_gps_pos_innov, gps_pos_innov_gates, gps_pos_obs_var, _gps_pos_innov_var, _gps_pos_test_ratio);
 		}
 
 	} else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)10e6)) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -300,7 +300,7 @@ void Ekf::controlExternalVisionFusion()
 			// innovation gate size
 			ev_pos_innov_gates(0) = fmaxf(_params.ev_pos_innov_gate, 1.0f);
 
-			fuseHorizontalPosition(_ev_pos_innov, ev_pos_innov_gates, ev_pos_obs_var, _ev_pos_innov_var, _ev_pos_test_ratio);
+			fuseHorizontalPosition(_ev_pos_innov, ev_pos_innov_gates, ev_pos_obs_var, _ev_pos_innov_var, _ev_pos_test_ratio, false);
 		}
 
 		// determine if we should use the velocity observations
@@ -712,7 +712,7 @@ void Ekf::controlGpsFusion()
 			// fuse GPS measurement
 			fuseHorizontalVelocity(_gps_vel_innov, gps_vel_innov_gates,gps_vel_obs_var, _gps_vel_innov_var, _gps_vel_test_ratio);
 			fuseVerticalVelocity(_gps_vel_innov, gps_vel_innov_gates, gps_vel_obs_var, _gps_vel_innov_var, _gps_vel_test_ratio);
-			fuseHorizontalPosition(_gps_pos_innov, gps_pos_innov_gates, gps_pos_obs_var, _gps_pos_innov_var, _gps_pos_test_ratio);
+			fuseHorizontalPosition(_gps_pos_innov, gps_pos_innov_gates, gps_pos_obs_var, _gps_pos_innov_var, _gps_pos_test_ratio, false);
 		}
 
 	} else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)10e6)) {
@@ -1289,11 +1289,10 @@ void Ekf::controlFakePosFusion()
 
 			_gps_pos_innov.xy() = Vector2f(_state.pos) - _last_known_posNE;
 
-			// glitch protection is not required so set gate to a large value
-			const Vector2f fake_pos_innov_gate(100.0f, 100.0f);
+			const Vector2f fake_pos_innov_gate(3.0f, 3.0f);
 
 			fuseHorizontalPosition(_gps_pos_innov, fake_pos_innov_gate, fake_pos_obs_var,
-						_gps_pos_innov_var, _gps_pos_test_ratio);
+						_gps_pos_innov_var, _gps_pos_test_ratio, true);
 		}
 
 	} else {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -622,7 +622,7 @@ private:
 				  Vector3f &innov_var, Vector2f &test_ratio);
 
 	bool fuseHorizontalPosition(const Vector3f &innov, const Vector2f &innov_gate, const Vector3f &obs_var,
-				    Vector3f &innov_var, Vector2f &test_ratio);
+				    Vector3f &innov_var, Vector2f &test_ratiov, bool inhibit_gate);
 
 	bool fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate, const Vector3f &obs_var,
 				  Vector3f &innov_var, Vector2f &test_ratio);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -622,7 +622,7 @@ private:
 				  Vector3f &innov_var, Vector2f &test_ratio);
 
 	bool fuseHorizontalPosition(const Vector3f &innov, const Vector2f &innov_gate, const Vector3f &obs_var,
-				    Vector3f &innov_var, Vector2f &test_ratiov, bool inhibit_gate);
+				    Vector3f &innov_var, Vector2f &test_ratiov, bool inhibit_gate = false);
 
 	bool fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate, const Vector3f &obs_var,
 				  Vector3f &innov_var, Vector2f &test_ratio);

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -97,7 +97,7 @@ bool Ekf::fuseVerticalVelocity(const Vector3f &innov, const Vector2f &innov_gate
 }
 
 bool Ekf::fuseHorizontalPosition(const Vector3f &innov, const Vector2f &innov_gate, const Vector3f &obs_var,
-				 Vector3f &innov_var, Vector2f &test_ratio)
+				 Vector3f &innov_var, Vector2f &test_ratio, bool inhibit_gate)
 {
 
 	innov_var(0) = P(7, 7) + obs_var(0);
@@ -107,7 +107,7 @@ bool Ekf::fuseHorizontalPosition(const Vector3f &innov, const Vector2f &innov_ga
 
 	const bool innov_check_pass = test_ratio(0) <= 1.0f;
 
-	if (innov_check_pass) {
+	if (innov_check_pass || inhibit_gate) {
 		if (!_fuse_hpos_as_odom) {
 			_time_last_hor_pos_fuse = _time_last_imu;
 

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -108,6 +108,10 @@ bool Ekf::fuseHorizontalPosition(const Vector3f &innov, const Vector2f &innov_ga
 	const bool innov_check_pass = test_ratio(0) <= 1.0f;
 
 	if (innov_check_pass || inhibit_gate) {
+		if (inhibit_gate && test_ratio(0) > sq(100.0f / innov_gate(0))) {
+			// always protect against extreme values that could result in a NaN
+			return false;
+		}
 		if (!_fuse_hpos_as_odom) {
 			_time_last_hor_pos_fuse = _time_last_imu;
 


### PR DESCRIPTION
This change fixes a bug that allowed IMU gyro errors large enough to cause large tilt errors prior to start of aiding, to not result in large innovation test ratios. When only 2 IMU's are being used in a multi EKF setup, this results in the EKF selector not switching as the test ratio due to the diverging position stays a small number due to the large gate, eg:

![Screen Shot 2021-01-19 at 9 08 53 pm](https://user-images.githubusercontent.com/3596952/105019845-ae42aa00-5a9a-11eb-88e3-53b3401a3bca.png)

Replay currently does not work on logs with multiple EKF's so I have been unable to test on the log that shows the defect.

TODO - test on a multi EKF setup with EKF2_MULTI_IMU=2 and SENS_ IMU_MNODE = 0 and while on ground without GPS, set CAL_GYRO0_XOFF to 0.5