### PR TITLE
Retain getEkfGlobalOrigin() method and refactor for simplicity, standardize naming convention with setEkfGlobalOrigin().

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -149,7 +149,11 @@ public:
 	// ask estimator for sensor data collection decision and do any preprocessing if required, returns true if not defined
 	bool collect_gps(const gps_message &gps) override;
 
-	bool setGlobalOrigin(const double &latitude, const double &longitude, const float &altitude);
+	// get the ekf WGS-84 origin position and height and the system time it was last set
+	// return true if the origin is valid
+	bool getEkfGlobalOrigin(uint64_t &origin_time, map_projection_reference_s &origin_pos, float &origin_alt) const;
+
+	bool setEkfGlobalOrigin(const double &latitude, const double &longitude, const float &altitude);
 
 	// get the 1-sigma horizontal and vertical position uncertainty of the ekf WGS-84 position
 	void get_ekf_gpos_accuracy(float *ekf_eph, float *ekf_epv) const;
@@ -461,6 +465,7 @@ private:
 	bool _gps_checks_passed{false};		///> true when all active GPS checks have passed
 
 	// Variables used to publish the WGS-84 location of the EKF local NED origin
+	uint64_t _last_gps_origin_time_us{0};	///< time the origin was last set (uSec)
 	float _gps_alt_ref{0.0f};		///< WGS-84 height (m)
 
 	// Variables used by the initial filter alignment

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -674,12 +674,20 @@ matrix::Vector<float, 24> Ekf::getStateAtFusionHorizonAsVector() const
 	return state;
 }
 
-bool Ekf::setGlobalOrigin(const double &latitude, const double &longitude, const float &altitude)
+bool Ekf::getEkfGlobalOrigin(uint64_t &origin_time, map_projection_reference_s &origin_pos, float &origin_alt) const
+{
+	origin_time = _last_gps_origin_time_us;
+	origin_pos  = _pos_ref;
+	origin_alt  = _gps_alt_ref;
+	return _NED_origin_initialised;
+}
+
+bool Ekf::setEkfGlobalOrigin(const double &latitude, const double &longitude, const float &altitude)
 {
 	bool current_pos_available = false;
 	double current_lat = NAN;
 	double current_lon = NAN;
-	float current_alt = NAN;
+	float current_alt  = NAN;
 
 	// if we are already doing aiding, correct for the change in position since the EKF started navigating
 	if (map_projection_initialized(&_pos_ref) && isHorizontalAidingActive()) {

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -82,6 +82,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 		_gps_alt_ref = 1e-3f * (float)gps.alt + _state.pos(2);
 		_NED_origin_initialised = true;
 		_earth_rate_NED = calcEarthRateNED((float)_pos_ref.lat_rad);
+		_last_gps_origin_time_us = _time_last_imu;
 
 		const bool declination_was_valid = ISFINITE(_mag_declination_gps);
 


### PR DESCRIPTION
Hi @dagar ,

This PR reverts the deletion of the `getEkfGlobalOrigin` method for the global origin and simplifies/aligns its' usage and naming convention with your added `setEkfGlobalOrigin` method.  I will continue iterating with you on the corresponding PX4-Autopilot PR [#16544](https://github.com/PX4/PX4-Autopilot/pull/16544)

Please let me know what questions/modifications you would like addressed with this PR.

Thanks!

-Mark