### PR TITLE
Heading reset to magnetometer from GPS or EV

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -334,7 +334,7 @@ void Ekf::controlExternalVisionFusion()
 			fuseHeading();
 		}
 
-	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel)
+	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel ||  _control_status.flags.ev_yaw)
 		   && isTimedOut(_time_last_ext_vision, (uint64_t)_params.reset_timeout_max)) {
 
 		// Turn off EV fusion mode if no data has been received

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -381,7 +381,7 @@ private:
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
 	bool _synthetic_mag_z_active{false};	///< true if we are generating synthetic magnetometer Z measurements
-	bool _no_other_yaw_aiding_than_mag{false};  ///< true when heading is not being fused from other sources than magnetometer (for example EV or GPS) 
+	bool _no_non_mag_heading_aiding_running{false};  ///< true when heading is not being fused from other sources than magnetometer (for example EV or GPS) 
 
 	bool _is_yaw_fusion_inhibited{false};		///< true when yaw sensor use is being inhibited
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -381,6 +381,7 @@ private:
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
 	bool _synthetic_mag_z_active{false};	///< true if we are generating synthetic magnetometer Z measurements
+	bool _no_other_yaw_aiding_than_mag{false};  ///< true when heading is not being fused from other sources than magnetometer (for example EV or GPS) 
 
 	bool _is_yaw_fusion_inhibited{false};		///< true when yaw sensor use is being inhibited
 
@@ -770,6 +771,7 @@ private:
 	void controlMagFusion();
 
 	bool noOtherYawAidingThanMag() const;
+	bool otherHeadingSourcesHaveFinished();
 
 	void checkHaglYawResetReq();
 	float getTerrainVPos() const { return isTerrainEstimateValid() ? _terrain_vpos : _last_on_ground_posD; }

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -381,7 +381,7 @@ private:
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
 	bool _synthetic_mag_z_active{false};	///< true if we are generating synthetic magnetometer Z measurements
-	bool _no_non_mag_heading_aiding_running{false};  ///< true when heading is not being fused from other sources than magnetometer (for example EV or GPS) 
+	bool _non_mag_yaw_aiding_running_prev{false};  ///< true when heading is being fused from other sources that are not the magnetometer (for example EV or GPS).
 
 	bool _is_yaw_fusion_inhibited{false};		///< true when yaw sensor use is being inhibited
 
@@ -771,7 +771,7 @@ private:
 	void controlMagFusion();
 
 	bool noOtherYawAidingThanMag() const;
-	bool otherHeadingSourcesHaveFinished();
+	bool otherHeadingSourcesHaveStopped();
 
 	void checkHaglYawResetReq();
 	float getTerrainVPos() const { return isTerrainEstimateValid() ? _terrain_vpos : _last_on_ground_posD; }

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -331,12 +331,10 @@ void Ekf::run3DMagAndDeclFusions()
 
 bool Ekf::otherHeadingSourcesHaveFinished()
 {
-    bool no_other_yaw_aiding_than_mag = noOtherYawAidingThanMag();
-
     // detect rising edge
-    bool result = no_other_yaw_aiding_than_mag && !_no_other_yaw_aiding_than_mag;
+    bool result = noOtherYawAidingThanMag() && !_no_non_mag_heading_aiding_running;
 
-    _no_other_yaw_aiding_than_mag = no_other_yaw_aiding_than_mag;
+    _no_non_mag_heading_aiding_running = noOtherYawAidingThanMag();
 
     return  result;
 }

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -72,7 +72,7 @@ void Ekf::controlMagFusion()
 		return;
 	}
 
-	_mag_yaw_reset_req |= otherHeadingSourcesHaveFinished();
+	_mag_yaw_reset_req |= otherHeadingSourcesHaveStopped();
 
 	if (noOtherYawAidingThanMag() && _mag_data_ready) {
 		if (_control_status.flags.in_air) {
@@ -329,12 +329,12 @@ void Ekf::run3DMagAndDeclFusions()
 	}
 }
 
-bool Ekf::otherHeadingSourcesHaveFinished()
+bool Ekf::otherHeadingSourcesHaveStopped()
 {
-    // detect rising edge
-    bool result = noOtherYawAidingThanMag() && !_no_non_mag_heading_aiding_running;
+    // detect rising edge of noOtherYawAidingThanMag()
+    bool result = noOtherYawAidingThanMag() && _non_mag_yaw_aiding_running_prev;
 
-    _no_non_mag_heading_aiding_running = noOtherYawAidingThanMag();
+    _non_mag_yaw_aiding_running_prev = !noOtherYawAidingThanMag();
 
     return  result;
 }

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -72,6 +72,8 @@ void Ekf::controlMagFusion()
 		return;
 	}
 
+	_mag_yaw_reset_req |= otherHeadingSourcesHaveFinished();
+
 	if (noOtherYawAidingThanMag() && _mag_data_ready) {
 		if (_control_status.flags.in_air) {
 			checkHaglYawResetReq();
@@ -327,3 +329,14 @@ void Ekf::run3DMagAndDeclFusions()
 	}
 }
 
+bool Ekf::otherHeadingSourcesHaveFinished()
+{
+    bool no_other_yaw_aiding_than_mag = noOtherYawAidingThanMag();
+
+    // detect rising edge
+    bool result = no_other_yaw_aiding_than_mag && !_no_other_yaw_aiding_than_mag;
+
+    _no_other_yaw_aiding_than_mag = no_other_yaw_aiding_than_mag;
+
+    return  result;
+}

--- a/test/test_EKF_gps_yaw.cpp
+++ b/test/test_EKF_gps_yaw.cpp
@@ -195,6 +195,8 @@ TEST_F(EkfGpsHeadingTest, fallBackToMag)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
 
+	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
+
 	// BUT WHEN: the GPS yaw is suddenly invalid
 	gps_heading = NAN;
 	_sensor_simulator._gps.setYaw(gps_heading);
@@ -204,4 +206,5 @@ TEST_F(EkfGpsHeadingTest, fallBackToMag)
 	// the estimator should fall back to mag fusion
 	EXPECT_FALSE(_ekf_wrapper.isIntendingGpsHeadingFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 1);
 }


### PR DESCRIPTION
**Issue found**
I have been flying an UAV with an intermittent external vision and I found that heading state did not reset to magnetometer when external vision failed. 

**Solution**
In _mag_control.cpp_ I added a logic which is aware of other sources of heading may stop contributing measures. Also, I extended the tests to catch that bug. 