### PR TITLE
Waiting for the filter to be initialized to set global origin

### DIFF
--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -61,7 +61,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 	// Run GPS checks always
 	_gps_checks_passed = gps_is_good(gps);
 
-	if (!_NED_origin_initialised && _gps_checks_passed) {
+	if (_filter_initialised && !_NED_origin_initialised && _gps_checks_passed) {
 		// If we have good GPS data set the origin's WGS-84 position to the last gps fix
 		const double lat = gps.lat * 1.0e-7;
 		const double lon = gps.lon * 1.0e-7;


### PR DESCRIPTION
We had cases at Wingtra when the GPS checks passed before the filter initialized

```
15.50 0:00:15 INFO: 2021_02_10_12_44_52: [ecl/EKF] EKF GPS checks passed (WGS-84 origin set)
...
33.50 0:00:33 INFO: 2021_02_10_12_45_10: [ecl/EKF] EKF aligned, (pressure height, IMU buf: 10, OBS buf: 6)
...
33.52 0:00:33 INFO: 2021_02_10_12_45_10: [ecl/EKF] EKF commencing GPS fusion
```

Resulting from that is that the global position altitude reference (_gps_alt_ref) is reset in EKF/ekf.cpp > initialiseFilter() after being initialized in EKF/gps_checks.cpp > collect_gps(). And then the global altitude is wrong.

The solution proposed would be to wait for the filter to be initialized before setting the global references. Another possibility would be to force the reset of all references (_NED_origin_initialised = false) on filter initialization