### PR TITLE
EKF: use flow for vel test ratio if only active source of horizontal aiding

### DIFF
--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -321,7 +321,7 @@ protected:
 	Vector2f _gps_pos_test_ratio;		// GPS position innovation consistency check ratios
 	Vector2f _ev_vel_test_ratio;		// EV velocity innovation consistency check ratios
 	Vector2f _ev_pos_test_ratio ;		// EV position innovation consistency check ratios
-	Vector2f _aux_vel_test_ratio;		// Auxiliray horizontal velocity innovation consistency check ratio
+	Vector2f _aux_vel_test_ratio;		// Auxiliary horizontal velocity innovation consistency check ratio
 	Vector2f _baro_hgt_test_ratio;		// baro height innovation consistency check ratios
 	Vector2f _rng_hgt_test_ratio;		// range finder height innovation consistency check ratios
 	float _optflow_test_ratio{};		// Optical flow innovation consistency check ratio


### PR DESCRIPTION
This is intended to improve multi-EKF selection in scenarios where you only have flow.

I'm open to suggestions if there's a better way to do this.