### PR TITLE
Terrain estimator reset counter

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -243,6 +243,7 @@ struct parameters {
 	float wind_vel_p_noise_scaler{0.5f};	///< scaling of wind process noise with vertical velocity
 	float terrain_p_noise{5.0f};		///< process noise for terrain offset (m/sec)
 	float terrain_gradient{0.5f};		///< gradient of terrain used to estimate process noise due to changing position (m/m)
+	float terrain_timeout{10.f};		///< maximum time for invalid bottom distance measurements before resetting terrain estimate (s)
 
 	// initialization errors
 	float switch_on_gyro_bias{0.1f};	///< 1-sigma gyro bias uncertainty at switch on (rad/sec)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -217,6 +217,9 @@ public:
 	// get the estimated terrain vertical position relative to the NED origin
 	float getTerrainVertPos() const { return _terrain_vpos; };
 
+	// get the number of times the vertical terrain position has been reset
+	uint8_t getTerrainVertPosResetCounter() const { return _terrain_vpos_reset_counter; };
+
 	// get the terrain variance
 	float get_terrain_var() const { return _terrain_var; }
 
@@ -510,6 +513,7 @@ private:
 	// Terrain height state estimation
 	float _terrain_vpos{0.0f};		///< estimated vertical position of the terrain underneath the vehicle in local NED frame (m)
 	float _terrain_var{1e4f};		///< variance of terrain position estimate (m**2)
+	uint8_t _terrain_vpos_reset_counter{0};	///< number of times _terrain_vpos has been reset
 	uint64_t _time_last_hagl_fuse{0};		///< last system time that a range sample was fused by the terrain estimator
 	uint64_t _time_last_fake_hagl_fuse{0};	///< last system time that a fake range sample was fused by the terrain estimator
 	bool _terrain_initialised{false};	///< true when the terrain estimator has been initialized

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -170,6 +170,7 @@ void Ekf::fuseHagl()
 		if (isTimedOut(_time_last_hagl_fuse, timeout)) {
 			_terrain_vpos = _state.pos(2) + meas_hagl;
 			_terrain_var = obs_variance;
+			_terrain_vpos_reset_counter++;
 
 		} else {
 			_innov_check_fail_status.flags.reject_hagl = true;

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -166,7 +166,8 @@ void Ekf::fuseHagl()
 
 	} else {
 		// If we have been rejecting range data for too long, reset to measurement
-		if (isTimedOut(_time_last_hagl_fuse, (uint64_t)10E6)) {
+		const uint64_t timeout = static_cast<uint64_t>(_params.terrain_timeout * 1e6f);
+		if (isTimedOut(_time_last_hagl_fuse, timeout)) {
 			_terrain_vpos = _state.pos(2) + meas_hagl;
 			_terrain_var = obs_variance;
 


### PR DESCRIPTION
Hi all!

This doesn't change any behaviour, but it keeps track of and exposes a reset counter for the terrain estimator. 

The reset counter can be used on the autopilot side to reset the terrain height setpoints in sync, which in turn can make it possible to make the terrain following / holding altitude modes more robust over uneven terrain, especially manmade and indoor environments. I intend to open a follow-up pull request on the PX4-Autopilot repo for that.