### PR TITLE
Height source vision: Fallback to rangefinder if available

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -787,7 +787,9 @@ void Ekf::controlHeightSensorTimeouts()
 	const bool continuous_bad_accel_hgt = isTimedOut(_time_good_vert_accel, (uint64_t)_params.bad_acc_reset_delay_us);
 
 	// check if height has been inertial deadreckoning for too long
-	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
+	// in vision hgt mode check for vision data
+	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6)  ||
+			 (_control_status.flags.ev_hgt && !isRecent(_time_last_ext_vision, 5 * EV_MAX_INTERVAL));
 
 	if (hgt_fusion_timeout || continuous_bad_accel_hgt) {
 
@@ -875,6 +877,19 @@ void Ekf::controlHeightSensorTimeouts()
 				request_height_reset = true;
 				failing_height_source = "ev";
 				new_height_source = "ev";
+
+			// Fallback to rangefinder data if available
+			} else if (_range_sensor.isHealthy()) {
+				setControlRangeHeight();
+				if (_control_status.flags.in_air && isTerrainEstimateValid()) {
+					_hgt_sensor_offset = _terrain_vpos;
+				} else if (_control_status.flags.in_air) {
+				    _hgt_sensor_offset = _range_sensor.getDistBottom() + _state.pos(2);
+			    } else {
+					_hgt_sensor_offset = _params.rng_gnd_clearance;
+				}
+				failing_height_source = "ev";
+				new_height_source = "rng";
 
 			} else if (!_baro_hgt_faulty) {
 				startBaroHgtFusion();
@@ -1061,11 +1076,13 @@ void Ekf::controlHeightFusion()
 
 	case VDIST_SENSOR_EV:
 
-		// don't start using EV data unless data is arriving frequently
+		// don't start using EV data unless data is arriving frequently, do not reset if pref mode was height
 		if (!_control_status.flags.ev_hgt && isRecent(_time_last_ext_vision, 2 * EV_MAX_INTERVAL)) {
 			fuse_height = true;
 			setControlEVHeight();
-			resetHeight();
+			if (!_control_status_prev.flags.rng_hgt) {
+				 resetHeight();
+			}
 		}
 
 		if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
@@ -1128,6 +1145,7 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_baro_hgt_innov,baro_hgt_innov_gate,
 				baro_hgt_obs_var, _baro_hgt_innov_var,_baro_hgt_test_ratio);
+			_time_last_hgt_fuse = _time_last_imu;
 
 		} else if (_control_status.flags.gps_hgt) {
 			Vector2f gps_hgt_innov_gate;
@@ -1140,6 +1158,7 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_gps_pos_innov,gps_hgt_innov_gate,
 				gps_hgt_obs_var, _gps_pos_innov_var, _gps_pos_test_ratio);
+			_time_last_hgt_fuse = _time_last_imu;
 
 		} else if (_control_status.flags.rng_hgt) {
 			Vector2f rng_hgt_innov_gate;
@@ -1155,6 +1174,7 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_rng_hgt_innov,rng_hgt_innov_gate,
 				rng_hgt_obs_var, _rng_hgt_innov_var,_rng_hgt_test_ratio);
+			_time_last_hgt_fuse = _time_last_imu;
 
 		} else if (_control_status.flags.ev_hgt) {
 			Vector2f ev_hgt_innov_gate;
@@ -1168,6 +1188,7 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_ev_pos_innov,ev_hgt_innov_gate,
 				ev_hgt_obs_var, _ev_pos_innov_var,_ev_pos_test_ratio);
+			_time_last_hgt_fuse = _time_last_imu;
 		}
 	}
 }

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1139,7 +1139,6 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_baro_hgt_innov,baro_hgt_innov_gate,
 				baro_hgt_obs_var, _baro_hgt_innov_var,_baro_hgt_test_ratio);
-			_time_last_hgt_fuse = _time_last_imu;
 
 		} else if (_control_status.flags.gps_hgt) {
 			Vector2f gps_hgt_innov_gate;
@@ -1152,7 +1151,6 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_gps_pos_innov,gps_hgt_innov_gate,
 				gps_hgt_obs_var, _gps_pos_innov_var, _gps_pos_test_ratio);
-			_time_last_hgt_fuse = _time_last_imu;
 
 		} else if (_control_status.flags.rng_hgt) {
 			Vector2f rng_hgt_innov_gate;
@@ -1168,7 +1166,6 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_rng_hgt_innov,rng_hgt_innov_gate,
 				rng_hgt_obs_var, _rng_hgt_innov_var,_rng_hgt_test_ratio);
-			_time_last_hgt_fuse = _time_last_imu;
 
 		} else if (_control_status.flags.ev_hgt) {
 			Vector2f ev_hgt_innov_gate;
@@ -1182,7 +1179,6 @@ void Ekf::controlHeightFusion()
 			// fuse height information
 			fuseVerticalPosition(_ev_pos_innov,ev_hgt_innov_gate,
 				ev_hgt_obs_var, _ev_pos_innov_var,_ev_pos_test_ratio);
-			_time_last_hgt_fuse = _time_last_imu;
 		}
 	}
 }

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -881,13 +881,7 @@ void Ekf::controlHeightSensorTimeouts()
 			// Fallback to rangefinder data if available
 			} else if (_range_sensor.isHealthy()) {
 				setControlRangeHeight();
-				if (_control_status.flags.in_air && isTerrainEstimateValid()) {
-					_hgt_sensor_offset = _terrain_vpos;
-				} else if (_control_status.flags.in_air) {
-				    _hgt_sensor_offset = _range_sensor.getDistBottom() + _state.pos(2);
-			    } else {
-					_hgt_sensor_offset = _params.rng_gnd_clearance;
-				}
+				request_height_reset = true;
 				failing_height_source = "ev";
 				new_height_source = "rng";
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -262,6 +262,18 @@ void Ekf::resetHeight()
 
 	// reset the vertical position
 	if (_control_status.flags.rng_hgt) {
+
+		// a fallback from vision height to rangefinder height happened
+		if(_control_status_prev.flags.ev_hgt) {
+			if (_control_status.flags.in_air && isTerrainEstimateValid()) {
+			    _hgt_sensor_offset = _terrain_vpos;
+			} else if (_control_status.flags.in_air) {
+				 _hgt_sensor_offset = _range_sensor.getDistBottom() + _state.pos(2);
+			} else {
+				_hgt_sensor_offset = _params.rng_gnd_clearance;
+			}
+		}
+
 		// update the state and associated variance
 		resetVerticalPositionTo(_hgt_sensor_offset - _range_sensor.getDistBottom());
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -263,8 +263,9 @@ void Ekf::resetHeight()
 	// reset the vertical position
 	if (_control_status.flags.rng_hgt) {
 
-		// a fallback from vision height to rangefinder height happened
-		if(_control_status_prev.flags.ev_hgt) {
+		// a fallback from any other height source to rangefinder happened
+		if(!_control_status_prev.flags.rng_hgt) {
+
 			if (_control_status.flags.in_air && isTerrainEstimateValid()) {
 			    _hgt_sensor_offset = _terrain_vpos;
 			} else if (_control_status.flags.in_air) {
@@ -272,6 +273,7 @@ void Ekf::resetHeight()
 			} else {
 				_hgt_sensor_offset = _params.rng_gnd_clearance;
 			}
+
 		}
 
 		// update the state and associated variance

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -168,7 +168,7 @@ bool Ekf::fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate
 	if (innov_check_pass) {
 		_innov_check_fail_status.flags.reject_ver_pos = false;
 		fuseVelPosHeight(innovation, innov_var(2), 5);
-
+		_time_last_hgt_fuse = _time_last_imu;
 		return true;
 
 	} else {

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -166,9 +166,10 @@ bool Ekf::fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate
 	}
 
 	if (innov_check_pass) {
+		_time_last_hgt_fuse = _time_last_imu;
 		_innov_check_fail_status.flags.reject_ver_pos = false;
 		fuseVelPosHeight(innovation, innov_var(2), 5);
-		_time_last_hgt_fuse = _time_last_imu;
+
 		return true;
 
 	} else {

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -166,7 +166,6 @@ bool Ekf::fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate
 	}
 
 	if (innov_check_pass) {
-		_time_last_hgt_fuse = _time_last_imu;
 		_innov_check_fail_status.flags.reject_ver_pos = false;
 		fuseVelPosHeight(innovation, innov_var(2), 5);
 

--- a/test/test_EKF_fusionLogic.cpp
+++ b/test/test_EKF_fusionLogic.cpp
@@ -379,6 +379,7 @@ TEST_F(EkfFusionLogicTest, doVisionHeightFusion)
 	_sensor_simulator.runSeconds(12);
 
 	// THEN: EKF should stop to intend to use vision height
-	// TODO: This is not happening
-	EXPECT_TRUE(_ekf_wrapper.isIntendingVisionHeightFusion()); // TODO: Needs to change
+
+	EXPECT_FALSE(_ekf_wrapper.isIntendingVisionHeightFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
 }


### PR DESCRIPTION
This implements a fallback mechanism to RangeFinder (if existing) and then to Baro, if vision is selected as primary EKF2 height source in case of vision timeouts.

fixes https://github.com/PX4/PX4-Autopilot/issues/16858