### PR TITLE
EKF feature options to disable features at compile time

### DIFF
--- a/.github/workflows/build_ekf_flags.yml
+++ b/.github/workflows/build_ekf_flags.yml
@@ -1,0 +1,31 @@
+
+name: Feature Build Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - CMAKE_OPTIONS: "-DECL_EKF_AIRSPEED_FUSION=OFF"
+          - CMAKE_OPTIONS: "-DECL_EKF_DRAG_FUSION=OFF"
+          - CMAKE_OPTIONS: "-DECL_EKF_GPS_YAW_FUSION=OFF"
+          - CMAKE_OPTIONS: "-DECL_EKF_OPTICAL_FLOW=OFF"
+          - CMAKE_OPTIONS: "-DECL_EKF_TERRAIN_EST=OFF"
+          - CMAKE_OPTIONS: "-DECL_EKF_YAW_ESTIMATOR_GSF=OFF"
+    container: px4io/px4-dev-base-focal:2020-09-14
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+    - name: build ${{matrix.config.CMAKE_OPTIONS}}
+      run: mkdir build && cd build && cmake ${{matrix.config.CMAKE_OPTIONS}} .. && make

--- a/EKF/CMakeLists.txt
+++ b/EKF/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015-2018 ECL Development Team. All rights reserved.
+#   Copyright (c) 2015-2021 ECL Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,27 +31,70 @@
 #
 ############################################################################
 
+option(ECL_EKF_AIRSPEED_FUSION "ecl/EKF airspeed fusion" ON)
+option(ECL_EKF_DRAG_FUSION "ecl/EKF drag fusion" ON)
+option(ECL_EKF_GPS_YAW_FUSION "ecl/EKF GPS yaw fusion" ON)
+option(ECL_EKF_OPTICAL_FLOW "ecl/EKF optical flow fusion" ON)
+option(ECL_EKF_TERRAIN_EST "ecl/EKF terrain estimator" ON)
+option(ECL_EKF_YAW_ESTIMATOR_GSF "ecl/EKF yaw estimator GSF" ON)
+
 add_library(ecl_EKF
-	airspeed_fusion.cpp
 	control.cpp
-	mag_control.cpp
 	covariance.cpp
-	drag_fusion.cpp
 	ekf.cpp
 	ekf_helper.cpp
 	estimator_interface.cpp
 	gps_checks.cpp
-	mag_fusion.cpp
-	optflow_fusion.cpp
-	sideslip_fusion.cpp
-	terrain_estimator.cpp
-	vel_pos_fusion.cpp
-	gps_yaw_fusion.cpp
 	imu_down_sampler.cpp
-	EKFGSF_yaw.cpp
+	mag_control.cpp
+	mag_fusion.cpp
 	sensor_range_finder.cpp
+	sideslip_fusion.cpp
 	utils.cpp
+	vel_pos_fusion.cpp
 )
+
+if(ECL_EKF_AIRSPEED_FUSION)
+	target_compile_definitions(ecl_EKF PUBLIC ECL_EKF_AIRSPEED_FUSION)
+	target_sources(ecl_EKF PRIVATE airspeed_fusion.cpp)
+else()
+	message(STATUS "ecl/EKF airspeed fusion disabled")
+endif()
+
+if(ECL_EKF_DRAG_FUSION)
+	target_compile_definitions(ecl_EKF PUBLIC ECL_EKF_DRAG_FUSION)
+	target_sources(ecl_EKF PRIVATE drag_fusion.cpp)
+else()
+	message(STATUS "ecl/EKF drag fusion disabled")
+endif()
+
+if(ECL_EKF_GPS_YAW_FUSION)
+	target_compile_definitions(ecl_EKF PUBLIC ECL_EKF_GPS_YAW_FUSION)
+	target_sources(ecl_EKF PRIVATE gps_yaw_fusion.cpp)
+else()
+	message(STATUS "ecl/EKF GPS yaw fusion disabled")
+endif()
+
+if(ECL_EKF_OPTICAL_FLOW)
+	target_compile_definitions(ecl_EKF PUBLIC ECL_EKF_OPTICAL_FLOW)
+	target_sources(ecl_EKF PRIVATE optflow_fusion.cpp)
+else()
+	message(STATUS "ecl/EKF optical flow disabled")
+endif()
+
+if(ECL_EKF_TERRAIN_EST)
+	target_compile_definitions(ecl_EKF PUBLIC ECL_EKF_TERRAIN_EST)
+	target_sources(ecl_EKF PRIVATE terrain_estimator.cpp)
+else()
+	message(STATUS "ecl/EKF terrain estimator disabled")
+endif()
+
+if(ECL_EKF_YAW_ESTIMATOR_GSF)
+	target_compile_definitions(ecl_EKF PUBLIC ECL_EKF_YAW_ESTIMATOR_GSF)
+	target_sources(ecl_EKF PRIVATE EKFGSF_yaw.cpp)
+else()
+	message(STATUS "ecl/EKF emergency yaw estimator GSF disabled")
+endif()
 
 add_dependencies(ecl_EKF prebuild_targets)
 target_compile_definitions(ecl_EKF PRIVATE -DMODULE_NAME="ecl/EKF")

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -128,12 +128,15 @@ struct rangeSample {
 	int8_t	    quality;    ///< Signal quality in percent (0...100%), where 0 = invalid signal, 100 = perfect signal, and -1 = unknown signal quality.
 };
 
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 struct airspeedSample {
 	uint64_t    time_us{0};		///< timestamp of the measurement (uSec)
 	float       true_airspeed;	///< true airspeed measurement (m/sec)
 	float       eas2tas;		///< equivalent to true airspeed factor
 };
+#endif // ECL_EKF_AIRSPEED_FUSION
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 struct flowSample {
 	uint64_t time_us{0};	///< timestamp of the integration period leading edge (uSec)
 	Vector2f flow_xy_rad;	///< measured delta angle of the image about the X and Y body axes (rad), RH rotation is positive
@@ -141,6 +144,7 @@ struct flowSample {
 	float    dt;		///< amount of integration time (sec)
 	uint8_t  quality;	///< quality indicator between 0 and 255
 };
+#endif // ECL_EKF_OPTICAL_FLOW
 
 struct extVisionSample {
 	uint64_t time_us{0};	///< timestamp of the measurement (uSec)
@@ -153,10 +157,12 @@ struct extVisionSample {
 	velocity_frame_t vel_frame = velocity_frame_t::BODY_FRAME_FRD;
 };
 
+#if defined(ECL_EKF_DRAG_FUSION)
 struct dragSample {
 	uint64_t time_us{0};	///< timestamp of the measurement (uSec)
 	Vector2f accelXY;	///< measured specific force along the X and Y body axes (m/sec**2)
 };
+#endif // ECL_EKF_DRAG_FUSION
 
 struct auxVelSample {
 	uint64_t time_us{0};	///< timestamp of the measurement (uSec)

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -1086,6 +1086,7 @@ void Ekf::zeroMagCov()
 
 void Ekf::resetWindCovariance()
 {
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	if (_tas_data_ready && (_imu_sample_delayed.time_us - _airspeed_sample_delayed.time_us < (uint64_t)5e5)) {
 		// Derived using EKF/matlab/scripts/Inertial Nav EKF/wind_cov.py
 		// TODO: explicitly include the sideslip angle in the derivation
@@ -1114,7 +1115,9 @@ void Ekf::resetWindCovariance()
 		P(22,22) += P(4,4);
 		P(23,23) += P(5,5);
 
-	} else {
+	} else
+#endif // ECL_EKF_AIRSPEED_FUSION
+	{
 		// without airspeed, start with a small initial uncertainty to improve the initial estimate
 		P.uncorrelateCovarianceSetVariance<2>(22, _params.initial_wind_uncertainty);
 	}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -119,13 +119,17 @@ bool Ekf::update()
 		// control fusion of observation data
 		controlFusionModes();
 
+#if defined(ECL_EKF_TERRAIN_EST)
 		// run a separate filter for terrain estimation
 		runTerrainEstimator();
+#endif // ECL_EKF_TERRAIN_EST
 
 		updated = true;
 
+#if defined(ECL_EKF_YAW_ESTIMATOR_GSF)
 		// run EKF-GSF yaw estimator
 		runYawEKFGSF();
+#endif // ECL_EKF_YAW_ESTIMATOR_GSF
 	}
 
 	// the output observer always runs
@@ -214,8 +218,10 @@ bool Ekf::initialiseFilter()
 		increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
 	}
 
+#if defined(ECL_EKF_TERRAIN_EST)
 	// try to initialise the terrain estimator
 	_terrain_initialised = initHagl();
+#endif // ECL_EKF_TERRAIN_EST
 
 	// reset the essential fusion timeout counters
 	_time_last_hgt_fuse = _time_last_imu;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -86,6 +86,7 @@ public:
 	void getAuxVelInnovVar(float aux_vel_innov[2]) const;
 	void getAuxVelInnovRatio(float &aux_vel_innov_ratio) const { aux_vel_innov_ratio = _aux_vel_test_ratio(0); }
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	void getFlowInnov(float flow_innov[2]) const { _flow_innov.copyTo(flow_innov); }
 	void getFlowInnovVar(float flow_innov_var[2]) const { _flow_innov_var.copyTo(flow_innov_var); }
 	void getFlowInnovRatio(float &flow_innov_ratio) const { flow_innov_ratio = _optflow_test_ratio; }
@@ -94,6 +95,7 @@ public:
 	const Vector2f &getFlowCompensated() const { return _flow_compensated_XY_rad; }
 	const Vector2f &getFlowUncompensated() const { return _flow_sample_delayed.flow_xy_rad; }
 	const Vector3f &getFlowGyro() const { return _flow_sample_delayed.gyro_xyz; }
+#endif // ECL_EKF_OPTICAL_FLOW
 
 	void getHeadingInnov(float &heading_innov) const { heading_innov = _heading_innov; }
 	void getHeadingInnovVar(float &heading_innov_var) const { heading_innov_var = _heading_innov_var; }
@@ -103,13 +105,17 @@ public:
 	void getMagInnovVar(float mag_innov_var[3]) const { _mag_innov_var.copyTo(mag_innov_var); }
 	void getMagInnovRatio(float &mag_innov_ratio) const { mag_innov_ratio = _mag_test_ratio.max(); }
 
+#if defined(ECL_EKF_DRAG_FUSION)
 	void getDragInnov(float drag_innov[2]) const { _drag_innov.copyTo(drag_innov); }
 	void getDragInnovVar(float drag_innov_var[2]) const { _drag_innov_var.copyTo(drag_innov_var); }
 	void getDragInnovRatio(float drag_innov_ratio[2]) const { _drag_test_ratio.copyTo(drag_innov_ratio); }
+#endif // ECL_EKF_DRAG_FUSION
 
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	void getAirspeedInnov(float &airspeed_innov) const { airspeed_innov = _airspeed_innov; }
 	void getAirspeedInnovVar(float &airspeed_innov_var) const { airspeed_innov_var = _airspeed_innov_var; }
 	void getAirspeedInnovRatio(float &airspeed_innov_ratio) const { airspeed_innov_ratio = _tas_test_ratio; }
+#endif // ECL_EKF_AIRSPEED_FUSION
 
 	void getBetaInnov(float &beta_innov) const { beta_innov = _beta_innov; }
 	void getBetaInnovVar(float &beta_innov_var) const { beta_innov_var = _beta_innov_var; }
@@ -291,10 +297,12 @@ public:
 	// set minimum continuous period without GPS fail required to mark a healthy GPS status
 	void set_min_required_gps_health_time(uint32_t time_us) { _min_gps_health_time_us = time_us; }
 
+#if defined(ECL_EKF_YAW_ESTIMATOR_GSF)
 	// get solution data from the EKF-GSF emergency yaw estimator
 	// returns false when data is not available
 	bool getDataEKFGSF(float *yaw_composite, float *yaw_variance, float yaw[N_MODELS_EKFGSF],
 			   float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]);
+#endif // ECL_EKF_YAW_ESTIMATOR_GSF
 
 private:
 
@@ -303,11 +311,13 @@ private:
 
 	bool initialiseTilt();
 
+#if defined(ECL_EKF_YAW_ESTIMATOR_GSF)
 	// Request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
 	// and reset the velocity and position states to the GPS. This will cause the EKF
 	// to ignore the magnetometer for the remainder of flight.
 	// This should only be used as a last resort before activating a loss of navigation failsafe
 	void requestEmergencyNavReset() { _do_ekfgsf_yaw_reset = true; }
+#endif // ECL_EKF_YAW_ESTIMATOR_GSF
 
 	// check if the EKF is dead reckoning horizontal velocity using inertial data only
 	void update_deadreckoning_status();
@@ -346,10 +356,12 @@ private:
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused
 	bool _mag_data_ready{false};	///< true when new magnetometer data has fallen behind the fusion time horizon and is available to be fused
 	bool _baro_data_ready{false};	///< true when new baro height data has fallen behind the fusion time horizon and is available to be fused
-	bool _flow_data_ready{false};	///< true when the leading edge of the optical flow integration period has fallen behind the fusion time horizon
 	bool _ev_data_ready{false};	///< true when new external vision system data has fallen behind the fusion time horizon and is available to be fused
 	bool _tas_data_ready{false};	///< true when new true airspeed data has fallen behind the fusion time horizon and is available to be fused
+#if defined(ECL_EKF_OPTICAL_FLOW)
+	bool _flow_data_ready{false};	///< true when the leading edge of the optical flow integration period has fallen behind the fusion time horizon
 	bool _flow_for_terrain_data_ready{false}; /// same flag as "_flow_data_ready" but used for separate terrain estimator
+#endif // ECL_EKF_OPTICAL_FLOW
 
 	uint64_t _time_prev_gps_us{0};	///< time stamp of previous GPS data retrieved from the buffer (uSec)
 	uint64_t _time_last_aiding{0};	///< amount of time we have been doing inertial only deadreckoning (uSec)
@@ -436,11 +448,15 @@ private:
 	Vector3f _mag_innov;		///< earth magnetic field innovations (Gauss)
 	Vector3f _mag_innov_var;	///< earth magnetic field innovation variance (Gauss**2)
 
+#if defined(ECL_EKF_DRAG_FUSION)
 	Vector2f _drag_innov;		///< multirotor drag measurement innovation (m/sec**2)
 	Vector2f _drag_innov_var;	///< multirotor drag measurement innovation variance ((m/sec**2)**2)
+#endif // ECL_EKF_DRAG_FUSION
 
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	float _airspeed_innov{0.0f};		///< airspeed measurement innovation (m/sec)
 	float _airspeed_innov_var{0.0f};	///< airspeed measurement innovation variance ((m/sec)**2)
+#endif // ECL_EKF_AIRSPEED_FUSION
 
 	float _beta_innov{0.0f};	///< synthetic sideslip measurement innovation (rad)
 	float _beta_innov_var{0.0f};	///< synthetic sideslip measurement innovation variance (rad**2)
@@ -448,6 +464,7 @@ private:
 	float _hagl_innov{0.0f};		///< innovation of the last height above terrain measurement (m)
 	float _hagl_innov_var{0.0f};		///< innovation variance for the last height above terrain measurement (m**2)
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	// optical flow processing
 	Vector2f _flow_innov;		///< flow measurement innovation (rad/sec)
 	Vector2f _flow_innov_var;	///< flow innovation variance ((rad/sec)**2)
@@ -460,6 +477,7 @@ private:
 	uint64_t _time_good_motion_us{0};	///< last system time that on-ground motion was within limits (uSec)
 	bool _inhibit_flow_use{false};	///< true when use of optical flow and range finder is being inhibited
 	Vector2f _flow_compensated_XY_rad;	///< measured delta angle of the image about the X and Y body axes after removal of body rotation (rad), RH rotation is positive
+#endif // ECL_EKF_OPTICAL_FLOW
 
 	// output predictor states
 	Vector3f _delta_angle_corr;	///< delta angle correction vector (rad)
@@ -580,8 +598,10 @@ private:
 	void updateQuaternion(const float innovation, const float variance, const float gate_sigma,
 			      const Vector4f &yaw_jacobian);
 
+#if defined(ECL_EKF_GPS_YAW_FUSION)
 	// fuse the yaw angle obtained from a dual antenna GPS unit
 	void fuseGpsYaw();
+#endif // ECL_EKF_GPS_YAW_FUSION
 
 	// reset the quaternions states using the yaw angle obtained from a dual antenna GPS unit
 	// return true if the reset was successful
@@ -594,8 +614,10 @@ private:
 	// apply sensible limits to the declination and length of the NE mag field states estimates
 	void limitDeclination();
 
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	// fuse airspeed measurement
 	void fuseAirspeed();
+#endif // ECL_EKF_AIRSPEED_FUSION
 
 	// fuse synthetic zero sideslip measurement
 	void fuseSideslip();
@@ -649,10 +671,13 @@ private:
 	bool fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate, const Vector3f &obs_var,
 				  Vector3f &innov_var, Vector2f &test_ratio);
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	// calculate optical flow body angular rate compensation
 	// returns false if bias corrected body rate data is unavailable
 	bool calcOptFlowBodyRateComp();
+#endif // ECL_EKF_OPTICAL_FLOW
 
+#if defined(ECL_EKF_TERRAIN_EST)
 	// initialise the terrain vertical position estimator
 	// return true if the initialisation is successful
 	bool initHagl();
@@ -668,6 +693,7 @@ private:
 
 	// update the terrain vertical position estimate using an optical flow measurement
 	void fuseFlowForTerrain();
+#endif // ECL_EKF_TERRAIN_EST
 
 	// reset the heading and magnetic field states using the declination and magnetometer/external vision measurements
 	// return true if successful
@@ -779,14 +805,18 @@ private:
 	// control fusion of external vision observations
 	void controlExternalVisionFusion();
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	// control fusion of optical flow observations
 	void controlOpticalFlowFusion();
 	void updateOnGroundMotionForOpticalFlowChecks();
 	void resetOnGroundMotionForOpticalFlowChecks();
+#endif // ECL_EKF_OPTICAL_FLOW
 
 	// control fusion of GPS observations
 	void controlGpsFusion();
+#if defined(ECL_EKF_GPS_YAW_FUSION)
 	void controlGpsYawFusion();
+#endif // ECL_EKF_GPS_YAW_FUSION
 
 	// control fusion of magnetometer observations
 	void controlMagFusion();
@@ -832,8 +862,10 @@ private:
 	// control fusion of synthetic sideslip observations
 	void controlBetaFusion();
 
+#if defined(ECL_EKF_DRAG_FUSION)
 	// control fusion of multi-rotor drag specific force observations
 	void controlDragFusion();
+#endif // ECL_EKF_DRAG_FUSION
 
 	// control fusion of pressure altitude observations
 	void controlBaroFusion();
@@ -882,8 +914,10 @@ private:
 	// return an estimation of the GPS altitude variance
 	float getGpsHeightVariance();
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	// calculate the measurement variance for the optical flow sensor
 	float calcOptFlowMeasVar();
+#endif // ECL_EKF_OPTICAL_FLOW
 
 	// rotate quaternion covariances into variances for an equivalent rotation vector
 	Vector3f calcRotVecVariances();
@@ -954,7 +988,9 @@ private:
 
 	void stopAuxVelFusion();
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	void stopFlowFusion();
+#endif // ECL_EKF_OPTICAL_FLOW
 
 	void setVelPosFaultStatus(const int index, const bool status);
 
@@ -964,6 +1000,7 @@ private:
 	// update_buffer : true if the state change should be also applied to the output observer buffer
 	void resetQuatStateYaw(float yaw, float yaw_variance, bool update_buffer);
 
+#if defined(ECL_EKF_YAW_ESTIMATOR_GSF)
 	// Declarations used to control use of the EKF-GSF yaw estimator
 
 	// yaw estimator instance
@@ -980,6 +1017,7 @@ private:
 	// Resets the horizontal velocity and position to the default navigation sensor
 	// Returns true if the reset was successful
 	bool resetYawToEKFGSF();
+#endif // ECL_EKF_YAW_ESTIMATOR_GSF
 
 	void resetGpsDriftCheckFilters();
 };

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -81,7 +81,9 @@ void EstimatorInterface::setIMUData(const imuSample &imu_sample)
 		// this will occur if data is overwritten before its time stamp falls behind the fusion time horizon
 		_min_obs_interval_us = (imu_sample.time_us - _imu_sample_delayed.time_us) / (_obs_buffer_length - 1);
 
+#if defined(ECL_EKF_DRAG_FUSION)
 		setDragData(imu_sample);
+#endif // ECL_EKF_DRAG_FUSION
 	}
 }
 
@@ -275,6 +277,7 @@ void EstimatorInterface::setBaroData(const baroSample &baro_sample)
 	}
 }
 
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 void EstimatorInterface::setAirspeedData(const airspeedSample &airspeed_sample)
 {
 	if (!_initialised || _airspeed_buffer_fail) {
@@ -304,6 +307,7 @@ void EstimatorInterface::setAirspeedData(const airspeedSample &airspeed_sample)
 		_airspeed_buffer.push(airspeed_sample_new);
 	}
 }
+#endif // ECL_EKF_AIRSPEED_FUSION
 
 void EstimatorInterface::setRangeData(const rangeSample &range_sample)
 {
@@ -334,6 +338,7 @@ void EstimatorInterface::setRangeData(const rangeSample &range_sample)
 	}
 }
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 void EstimatorInterface::setOpticalFlowData(const flowSample &flow)
 {
 	if (!_initialised || _flow_buffer_fail) {
@@ -363,6 +368,7 @@ void EstimatorInterface::setOpticalFlowData(const flowSample &flow)
 		_flow_buffer.push(optflow_sample_new);
 	}
 }
+#endif // ECL_EKF_OPTICAL_FLOW
 
 // set attitude and position data derived from an external vision system
 void EstimatorInterface::setExtVisionData(const extVisionSample &evdata)
@@ -425,6 +431,7 @@ void EstimatorInterface::setAuxVelData(const auxVelSample &auxvel_sample)
 	}
 }
 
+#if defined(ECL_EKF_DRAG_FUSION)
 void EstimatorInterface::setDragData(const imuSample &imu)
 {
 	// down-sample the drag specific force data by accumulating and calculating the mean when
@@ -442,7 +449,7 @@ void EstimatorInterface::setDragData(const imuSample &imu)
 			}
 		}
 
-		_drag_sample_count ++;
+		_drag_sample_count++;
 		// note acceleration is accumulated as a delta velocity
 		_drag_down_sampled.accelXY(0) += imu.delta_vel(0);
 		_drag_down_sampled.accelXY(1) += imu.delta_vel(1);
@@ -474,6 +481,7 @@ void EstimatorInterface::setDragData(const imuSample &imu)
 		}
 	}
 }
+#endif // ECL_EKF_DRAG_FUSION
 
 bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 {
@@ -572,10 +580,16 @@ void EstimatorInterface::print_status()
 	ECL_INFO("mag buffer: %d (%d Bytes)", _mag_buffer.get_length(), _mag_buffer.get_total_size());
 	ECL_INFO("baro buffer: %d (%d Bytes)", _baro_buffer.get_length(), _baro_buffer.get_total_size());
 	ECL_INFO("range buffer: %d (%d Bytes)", _range_buffer.get_length(), _range_buffer.get_total_size());
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	ECL_INFO("airspeed buffer: %d (%d Bytes)", _airspeed_buffer.get_length(), _airspeed_buffer.get_total_size());
+#endif // ECL_EKF_AIRSPEED_FUSION
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	ECL_INFO("flow buffer: %d (%d Bytes)", _flow_buffer.get_length(), _flow_buffer.get_total_size());
+#endif // ECL_EKF_OPTICAL_FLOW
 	ECL_INFO("vision buffer: %d (%d Bytes)", _ext_vision_buffer.get_length(), _ext_vision_buffer.get_total_size());
 	ECL_INFO("output buffer: %d (%d Bytes)", _output_buffer.get_length(), _output_buffer.get_total_size());
 	ECL_INFO("output vert buffer: %d (%d Bytes)", _output_vert_buffer.get_length(), _output_vert_buffer.get_total_size());
+#if defined(ECL_EKF_DRAG_FUSION)
 	ECL_INFO("drag buffer: %d (%d Bytes)", _drag_buffer.get_length(), _drag_buffer.get_total_size());
+#endif // ECL_EKF_DRAG_FUSION
 }

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -77,12 +77,16 @@ public:
 
 	void setBaroData(const baroSample &baro_sample);
 
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	void setAirspeedData(const airspeedSample &airspeed_sample);
+#endif // ECL_EKF_AIRSPEED_FUSION
 
 	void setRangeData(const rangeSample &range_sample);
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	// if optical flow sensor gyro delta angles are not available, set gyro_xyz vector fields to NaN and the EKF will use its internal delta angle data instead
 	void setOpticalFlowData(const flowSample &flow);
+#endif // ECL_EKF_OPTICAL_FLOW
 
 	// set external vision position and attitude data
 	void setExtVisionData(const extVisionSample &evdata);
@@ -280,11 +284,17 @@ protected:
 	baroSample _baro_sample_delayed{};
 	gpsSample _gps_sample_delayed{};
 	sensor::SensorRangeFinder _range_sensor{};
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	airspeedSample _airspeed_sample_delayed{};
+#endif // ECL_EKF_AIRSPEED_FUSION
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	flowSample _flow_sample_delayed{};
+#endif // ECL_EKF_OPTICAL_FLOW
 	extVisionSample _ev_sample_delayed{};
+#if defined(ECL_EKF_DRAG_FUSION)
 	dragSample _drag_sample_delayed{};
 	dragSample _drag_down_sampled{};	// down sampled drag specific force data (filter prediction rate -> observation rate)
+#endif // ECL_EKF_DRAG_FUSION
 	auxVelSample _auxvel_sample_delayed{};
 
 	float _air_density{CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C};		// air density (kg/m**3)
@@ -353,10 +363,16 @@ protected:
 	RingBuffer<magSample> _mag_buffer;
 	RingBuffer<baroSample> _baro_buffer;
 	RingBuffer<rangeSample> _range_buffer;
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	RingBuffer<airspeedSample> _airspeed_buffer;
+#endif // ECL_EKF_AIRSPEED_FUSION
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	RingBuffer<flowSample> 	_flow_buffer;
+#endif // ECL_EKF_OPTICAL_FLOW
 	RingBuffer<extVisionSample> _ext_vision_buffer;
+#if defined(ECL_EKF_DRAG_FUSION)
 	RingBuffer<dragSample> _drag_buffer;
+#endif // ECL_EKF_DRAG_FUSION
 	RingBuffer<auxVelSample> _auxvel_buffer;
 
 	// timestamps of latest in buffer saved measurement in microseconds
@@ -420,9 +436,11 @@ private:
 	float _baro_alt_sum{0.0f};			// summed pressure altitude readings (m)
 	uint8_t _baro_sample_count{0};		// number of barometric altitude measurements summed
 
+#if defined(ECL_EKF_DRAG_FUSION)
 	// Used by the multi-rotor specific drag force fusion
 	uint8_t _drag_sample_count{0};	// number of drag specific force samples assumulated at the filter prediction rate
 	float _drag_sample_time_dt{0.0f};	// time integral across all samples used to form _drag_down_sampled (sec)
+#endif // ECL_EKF_DRAG_FUSION
 
 	// Used to downsample magnetometer data
 	uint64_t _mag_timestamp_sum{0};
@@ -434,10 +452,16 @@ private:
 	bool _mag_buffer_fail{false};
 	bool _baro_buffer_fail{false};
 	bool _range_buffer_fail{false};
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 	bool _airspeed_buffer_fail{false};
+#endif // ECL_EKF_AIRSPEED_FUSION
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	bool _flow_buffer_fail{false};
+#endif // ECL_EKF_OPTICAL_FLOW
 	bool _ev_buffer_fail{false};
+#if defined(ECL_EKF_DRAG_FUSION)
 	bool _drag_buffer_fail{false};
+#endif // ECL_EKF_DRAG_FUSION
 	bool _auxvel_buffer_fail{false};
 
 };

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -93,9 +93,11 @@ bool Ekf::collect_gps(const gps_message &gps)
 
 		// request a reset of the yaw using the new declination
 		if (_params.mag_fusion_type == MAG_FUSE_TYPE_NONE) {
+#if defined(ECL_EKF_YAW_ESTIMATOR_GSF)
 			// try to reset the yaw using the EKF-GSF yaw estimator
 			_do_ekfgsf_yaw_reset = true;
 			_ekfgsf_yaw_reset_time = 0;
+#endif // ECL_EKF_YAW_ESTIMATOR_GSF
 
 		} else {
 			if (!declination_was_valid) {

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -139,7 +139,9 @@ void Ekf::fuseSideslip()
 			// if we are getting aiding from other sources, warn and reset the wind states and covariances only
 			const char* action_string = nullptr;
 			if (update_wind_only) {
+#if defined(ECL_EKF_AIRSPEED_FUSION)
 				resetWindStates();
+#endif // ECL_EKF_AIRSPEED_FUSION
 				resetWindCovariance();
 				action_string = "wind";
 

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -64,13 +64,14 @@ bool Ekf::initHagl()
 		// success
 		initialized = true;
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	} else if (shouldUseOpticalFlowForHagl()
 		   && _flow_for_terrain_data_ready) {
 		// initialise terrain vertical position to origin as this is the best guess we have
 		_terrain_vpos = fmaxf(0.0f,  _state.pos(2));
 		_terrain_var = 100.0f;
 		initialized = true;
-
+#endif // ECL_EKF_OPTICAL_FLOW
 	} else {
 		// no information - cannot initialise
 	}
@@ -115,11 +116,13 @@ void Ekf::runTerrainEstimator()
 			fuseHagl();
 		}
 
+#if defined(ECL_EKF_OPTICAL_FLOW)
 		if (shouldUseOpticalFlowForHagl()
 		    && _flow_for_terrain_data_ready) {
 			fuseFlowForTerrain();
 			_flow_for_terrain_data_ready = false;
 		}
+#endif // ECL_EKF_OPTICAL_FLOW
 
 		// constrain _terrain_vpos to be a minimum of _params.rng_gnd_clearance larger than _state.pos(2)
 		if (_terrain_vpos - _state.pos(2) < _params.rng_gnd_clearance) {
@@ -180,6 +183,7 @@ void Ekf::fuseHagl()
 
 void Ekf::fuseFlowForTerrain()
 {
+#if defined(ECL_EKF_OPTICAL_FLOW)
 	// calculate optical LOS rates using optical flow rates that have had the body angular rate contribution removed
 	// correct for gyro bias errors in the data used to do the motion compensation
 	// Note the sign convention used: A positive LOS rate is a RH rotation of the scene about that axis.
@@ -276,6 +280,7 @@ void Ekf::fuseFlowForTerrain()
 		_terrain_var = fmaxf(_terrain_var - KyHyP, 0.0f);
 		_time_last_flow_terrain_fuse = _time_last_imu;
 	}
+#endif // ECL_EKF_OPTICAL_FLOW
 }
 
 void Ekf::updateTerrainValidity()


### PR DESCRIPTION
The EKF when used within PX4 (ekf2) is a relatively enormous 124 kB to 161 kB of flash depending on optimization level (-Os vs -O2). This can become problematic for inclusion on relatively flash constrained boards that might be found in FPV quadcopters (with GPS) or CAN peripheral nodes.

Are there certain features we can completely strip out at build time for simpler cases? Everything would still be on by default, but specific builds could then start to specialize.

Ideas
 - GPS heading fusion (requires higher end GPS most don't have)
 - airspeed fusion (maybe could be captured in something more general for fixed-wing usage?)
 - drag fusion
 - vision
