### PR TITLE
Allow RangeFinder fusion in vision height mode (Fix for #994)

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1079,20 +1079,13 @@ void Ekf::controlHeightFusion()
 			}
 		}
 
-		if (_control_status.flags.rng_hgt && _range_sensor.isDataHealthy()) {
-			// Allow RangeFinder Fusion
-			fuse_height = true;
-		}
-
-		if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
-			// switch to baro if there was a reset to baro
-			fuse_height = true;
-		}
-
-		// determine if we should use the vertical position observation
-		if (_control_status.flags.ev_hgt) {
-			fuse_height = true;
-		}
+		if (_control_status.flags.ev_hgt && _ev_data_ready) {
+		     fuse_height = true;
+		} else if (_control_status.flags.rng_hgt && _range_sensor.isDataHealthy()) {
+		      fuse_height = true;
+		} else if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
+		      fuse_height = true;
+	    }
 
 		break;
 	}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1079,6 +1079,11 @@ void Ekf::controlHeightFusion()
 			}
 		}
 
+		if (_control_status.flags.rng_hgt) {
+			// Allow RangeFinder Fusion
+			fuse_height = true;
+		}
+
 		if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
 			// switch to baro if there was a reset to baro
 			fuse_height = true;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -788,8 +788,7 @@ void Ekf::controlHeightSensorTimeouts()
 
 	// check if height has been inertial deadreckoning for too long
 	// in vision hgt mode check for vision data
-	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6)  ||
-			 (_control_status.flags.ev_hgt && !isRecent(_time_last_ext_vision, 5 * EV_MAX_INTERVAL));
+	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
 
 	if (hgt_fusion_timeout || continuous_bad_accel_hgt) {
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1079,7 +1079,7 @@ void Ekf::controlHeightFusion()
 			}
 		}
 
-		if (_control_status.flags.rng_hgt) {
+		if (_control_status.flags.rng_hgt && _range_sensor.isDataHealthy()) {
 			// Allow RangeFinder Fusion
 			fuse_height = true;
 		}


### PR DESCRIPTION
Although `controlHeightSensorTimeouts()` switched to` rng_hgt` mode correctly as soon as an ev timeout happens, range finder height fusion is not performed as `rng_hgt` is not allowed if vision is the primary height source. This PR allows range finder height fusion even if vision is selected as primary height source.

Relates to https://github.com/PX4/PX4-ECL/pull/994


