### PR TITLE
EKF: Extend drag fusion to include propeller momentum drag

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -351,8 +351,9 @@ struct parameters {
 
 	// multi-rotor drag specific force fusion
 	float drag_noise{2.5f};			///< observation noise variance for drag specific force measurements (m/sec**2)**2
-	float bcoef_x{25.0f};			///< ballistic coefficient along the X-axis (kg/m**2)
-	float bcoef_y{25.0f};			///< ballistic coefficient along the Y-axis (kg/m**2)
+	float bcoef_x{100.0f};			///< bluff body drag ballistic coefficient for the X-axis (kg/m**2)
+	float bcoef_y{100.0f};			///< bluff body drag ballistic coefficient for the Y-axis (kg/m**2)
+	float mcoef{0.1f};			///< rotor momentum drag coefficient for the X and Y axes (1/s)
 
 	// control of accel error detection and mitigation (IMU clipping)
 	const float vert_innov_test_lim{3.0f};	///< Number of standard deviations allowed before the combined vertical velocity and position test is declared as failed

--- a/EKF/drag_fusion.cpp
+++ b/EKF/drag_fusion.cpp
@@ -62,9 +62,6 @@ void Ekf::fuseDrag()
 		return;
 	}
 
-	// calculate inverse of ballistic coefficient
-	const Vector2f ballistic_coef_inv_xy(1.f / _params.bcoef_x, 1.f / _params.bcoef_y);
-
 	// get latest estimated orientation
 	const float &q0 = _state.quat_nominal(0);
 	const float &q1 = _state.quat_nominal(1);
@@ -101,9 +98,10 @@ void Ekf::fuseDrag()
 			float Kacc; // Derivative of specific force wrt airspeed
 			if (using_mcoef && using_bcoef_x) {
 				// bluff body and propeller momentum drag
-				const float airspeed = (_params.bcoef_x  / rho) * (- _params.mcoef  + sqrtf(sq(_params.mcoef ) + 2.0f * (rho / _params.bcoef_x ) * fabsf(mea_acc)));
-				Kacc = fmaxf(1e-1f, (rho / _params.bcoef_x) * airspeed + _params.mcoef  * density_ratio);
-				pred_acc = (0.5f / _params.bcoef_x ) * rho * sq(rel_wind_body(0)) * drag_sign - rel_wind_body(0) * _params.mcoef  * density_ratio;
+				const float bcoef_inv = 1.0f / _params.bcoef_x;
+				const float airspeed = (_params.bcoef_x  / rho) * (- _params.mcoef  + sqrtf(sq(_params.mcoef) + 2.0f * rho * bcoef_inv * fabsf(mea_acc)));
+				Kacc = fmaxf(1e-1f, rho * bcoef_inv * airspeed + _params.mcoef  * density_ratio);
+				pred_acc = 0.5f * bcoef_inv * rho * sq(rel_wind_body(0)) * drag_sign - rel_wind_body(0) * _params.mcoef  * density_ratio;
 			} else if (using_mcoef) {
 				// propeller momentum drag only
 				Kacc = fmaxf(1e-1f, _params.mcoef  * density_ratio);
@@ -111,8 +109,9 @@ void Ekf::fuseDrag()
 			} else if (using_bcoef_x) {
 				// bluff body drag only
 				const float airspeed = sqrtf((2.0f * _params.bcoef_x  * fabsf(mea_acc)) / rho);
-				Kacc = fmaxf(1e-1f, (rho / _params.bcoef_x ) * airspeed);
-				pred_acc = (0.5f / _params.bcoef_x ) * rho * sq(rel_wind_body(0)) * drag_sign;
+				const float bcoef_inv = 1.0f / _params.bcoef_x;
+				Kacc = fmaxf(1e-1f, rho * bcoef_inv * airspeed);
+				pred_acc = 0.5f * bcoef_inv * rho * sq(rel_wind_body(0)) * drag_sign;
 			} else {
 				// skip this axis
 				continue;
@@ -205,9 +204,10 @@ void Ekf::fuseDrag()
 			float Kacc; // Derivative of specific force wrt airspeed
 			if (using_mcoef && using_bcoef_y) {
 				// bluff body and propeller momentum drag
-				const float airspeed = (_params.bcoef_y / rho) * (- _params.mcoef  + sqrtf(sq(_params.mcoef ) + 2.0f * (rho / _params.bcoef_y) * fabsf(mea_acc)));
-				Kacc = fmaxf(1e-1f, (rho / _params.bcoef_y) * airspeed + _params.mcoef  * density_ratio);
-				pred_acc = (0.5f / _params.bcoef_y) * rho * sq(rel_wind_body(1)) * drag_sign - rel_wind_body(1) * _params.mcoef  * density_ratio;
+				const float bcoef_inv = 1.0f / _params.bcoef_y;
+				const float airspeed = (_params.bcoef_y / rho) * (- _params.mcoef  + sqrtf(sq(_params.mcoef) + 2.0f * rho * bcoef_inv * fabsf(mea_acc)));
+				Kacc = fmaxf(1e-1f, rho * bcoef_inv * airspeed + _params.mcoef  * density_ratio);
+				pred_acc = 0.5f * bcoef_inv * rho * sq(rel_wind_body(1)) * drag_sign - rel_wind_body(1) * _params.mcoef  * density_ratio;
 			} else if (using_mcoef) {
 				// propeller momentum drag only
 				Kacc = fmaxf(1e-1f, _params.mcoef  * density_ratio);
@@ -215,8 +215,9 @@ void Ekf::fuseDrag()
 			} else if (using_bcoef_y) {
 				// bluff body drag only
 				const float airspeed = sqrtf((2.0f * _params.bcoef_y * fabsf(mea_acc)) / rho);
-				Kacc = fmaxf(1e-1f, (rho / _params.bcoef_y) * airspeed);
-				pred_acc = (0.5f / _params.bcoef_y) * rho * sq(rel_wind_body(1)) * drag_sign;
+				const float bcoef_inv = 1.0f / _params.bcoef_y;
+				Kacc = fmaxf(1e-1f, rho * bcoef_inv * airspeed);
+				pred_acc = 0.5f * bcoef_inv * rho * sq(rel_wind_body(1)) * drag_sign;
 			} else {
 				// nothing more to do
 				return;

--- a/EKF/drag_fusion.cpp
+++ b/EKF/drag_fusion.cpp
@@ -92,7 +92,7 @@ void Ekf::fuseDrag()
 		const float mea_acc = _drag_sample_delayed.accelXY(axis_index)  - _state.delta_vel_bias(axis_index) / _dt_ekf_avg;
 
 		// predicted drag force sign is opposite to predicted wind relative velocity
-		const float drag_sign = (rel_wind_body(axis_index) >= 0.f) ? 1.f : -1.f;
+		const float drag_sign = (rel_wind_body(axis_index) >= 0.f) ? -1.f : 1.f;
 
 		float pred_acc; // predicted drag acceleration
 		if (axis_index == 0) {

--- a/EKF/python/ekf_derivation/main.py
+++ b/EKF/python/ekf_derivation/main.py
@@ -248,8 +248,12 @@ def body_frame_accel_observation(P,state,R_to_body,vx,vy,vz,wx,wy):
 
     # Use this nonlinear model for the prediction in the implementation only
     # It uses a ballistic coefficient for each axis and a propeller momentum drag coefficient
-    # accXpred = -sign(vrel[0]) * 0.5*rho*vrel[0]*(vrel[0]/BCoefX + MCoef) # predicted acceleration measured along X body axis
-    # accYpred = -sign(vrel[1]) * 0.5*rho*vrel[1]*(vrel[1]/BCoefY + MCoef) # predicted acceleration measured along Y body axis
+    #
+    # accXpred = -sign(vrel[0]) * vrel[0]*(0.5*rho*vrel[0]/BCoefX + MCoef) # predicted acceleration measured along X body axis
+    # accYpred = -sign(vrel[1]) * vrel[1]*(0.5*rho*vrel[1]/BCoefY + MCoef) # predicted acceleration measured along Y body axis
+    #
+    # BcoefX and BcoefY have units of Kg/m^2
+    # Mcoef has units of 1/s
 
     # Use a simple viscous drag model for the linear estimator equations
     # Use the the derivative from speed to acceleration averaged across the

--- a/EKF/python/ekf_derivation/main.py
+++ b/EKF/python/ekf_derivation/main.py
@@ -247,9 +247,9 @@ def body_frame_accel_observation(P,state,R_to_body,vx,vy,vz,wx,wy):
     vrel = R_to_body*Matrix([vx-wx,vy-wy,vz]) # predicted wind relative velocity
 
     # Use this nonlinear model for the prediction in the implementation only
-    # It uses a ballistic coefficient for each axis
-    # accXpred = -0.5*rho*vrel[0]*vrel[0]*BCXinv # predicted acceleration measured along X body axis
-    # accYpred = -0.5*rho*vrel[1]*vrel[1]*BCYinv # predicted acceleration measured along Y body axis
+    # It uses a ballistic coefficient for each axis and a propeller momentum drag coefficient
+    # accXpred = -sign(vrel[0]) * 0.5*rho*vrel[0]*(vrel[0]/BCoefX + MCoef) # predicted acceleration measured along X body axis
+    # accYpred = -sign(vrel[1]) * 0.5*rho*vrel[1]*(vrel[1]/BCoefY + MCoef) # predicted acceleration measured along Y body axis
 
     # Use a simple viscous drag model for the linear estimator equations
     # Use the the derivative from speed to acceleration averaged across the


### PR DESCRIPTION
This adds an additional drag term to the aerodynamic drag observation model use for multi-copter wind estimation that captures the momentum drag from lift propellers that varies with speed not speed^2 and is the dominant drag term for most of the multi-rotor flight envelope.

TODO - tuning on an example airframe

See https://github.com/priseborough/PX4-Autopilot/tree/pr-ekf_momentum_drag for PX4-Autopilot changes that expose the tuning parameter to the user.

This was tested using SITL gazebo by adding a 5m/s wind which produced a 1.8 m/s/s lateral body specific force.

For the first test the momentum drag model was tested using the following parameters

EKF2_AID_MASK = 33
EKF2_MCOEF = 0.36
EKF2_BCOEF_X,Y = 0 (disabled)

which gave the expected result:

<img width="1304" alt="Screen Shot 2021-06-10 at 5 23 14 pm" src="https://user-images.githubusercontent.com/3596952/121492408-327dd580-ca1a-11eb-9161-af8f83370b14.png">

The ballistic coefficient drag model was then tested using

EKF2_AID_MASK = 33
EKF2_MCOEF = 0 (disabled)
EKF2_BCOEF_X,Y = 8.5

<img width="1297" alt="Screen Shot 2021-06-10 at 6 02 20 pm" src="https://user-images.githubusercontent.com/3596952/121492631-5f31ed00-ca1a-11eb-9422-a895d7c6725f.png">
