### PR TITLE
EV_yaw: reset ev_to_ekf to identity when yaw is reset to EV

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -532,6 +532,7 @@ bool Ekf::resetYawToEv()
 	const float yaw_new_variance = fmaxf(_ev_sample_delayed.angVar, sq(1.0e-2f));
 
 	resetQuatStateYaw(yaw_new, yaw_new_variance, true);
+	_R_ev_to_ekf.setIdentity();
 
 	return true;
 }


### PR DESCRIPTION
Otherwise, the old rotation matrix is used and not updated anymore because the EKF is fusing EV yaw data.

Note that this issue only occurs when `MASK_ROTATE_EV` and `MASK_EV_YAW` are set at the same time (because otherwise, if `MASK_ROTATE_EV` isn't set, the wrong rotation matrix is never used).

Explanation of the race condition:
1. Initially, EV yaw fusion isn't active, the rotation matrix between the local frame (NED, initialized using mag) and EV frame is computed
2. EV yaw starts, the yaw estimate is reset to the EV yaw
3. During the fusion, if `MASK_ROTATE_EV` is set, the data is rotated using the rotation matrix computed in 1 (which is now wrong)
4. Because EV yaw fusion is now active, the rotation matrix isn't updated anymore

Added a unit test that triggers the race condition above (fails without the fix).