### PR TITLE
EKF: initialize vertical position and velocity variables

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -408,10 +408,10 @@ private:
 	Vector3f _last_vel_obs;			///< last velocity observation (m/s)
 	Vector3f _last_vel_obs_var;		///< last velocity observation variance (m/s)**2
 	Vector2f _last_fail_hvel_innov;		///< last failed horizontal velocity innovation (m/s)**2
-	float _vert_pos_innov_ratio;		///< vertical position innovation divided by estimated standard deviation of innovation
-	uint64_t _vert_pos_fuse_attempt_time_us;	///< last system time in usec vertical position measurement fuson was attempted
-	float _vert_vel_innov_ratio;		///< standard deviation of vertical velocity innovation
-	uint64_t _vert_vel_fuse_time_us;	///< last system time in usec time vertical velocity measurement fuson was attempted
+	float _vert_pos_innov_ratio{0.f};	///< vertical position innovation divided by estimated standard deviation of innovation
+	uint64_t _vert_pos_fuse_attempt_time_us{0};	///< last system time in usec vertical position measurement fuson was attempted
+	float _vert_vel_innov_ratio{0.f};		///< standard deviation of vertical velocity innovation
+	uint64_t _vert_vel_fuse_time_us{0};	///< last system time in usec time vertical velocity measurement fuson was attempted
 
 	Vector3f _gps_vel_innov;	///< GPS velocity innovations (m/sec)
 	Vector3f _gps_vel_innov_var;	///< GPS velocity innovation variances ((m/sec)**2)


### PR DESCRIPTION
 - otherwise checkVerticalAccelerationHealth() can fail if GPS or EV aren't available to correctly set vertical velocity fusion time and innovation ratio